### PR TITLE
Bug: evaluation order of StringsRow.matches_tags?

### DIFF
--- a/lib/twine/stringsfile.rb
+++ b/lib/twine/stringsfile.rb
@@ -23,12 +23,12 @@ module Twine
     end
     
     def matches_tags?(tags)
-      if @tags == nil || @tags.length == 0
-        # This row has no tags. Never match
-        return false
-      elsif tags == nil || tags.length == 0
+      if tags == nil || tags.length == 0
         # The user did not specify any tags. Everything passes.
         return true
+      elsif @tags == nil || @tags.length == 0
+        # This row has no tags. Never match
+        return false
       else
         tags.each do |tag|
           if @tags.include? tag


### PR DESCRIPTION
Hi, 

I could not parse simple strings.txt like,

```
[[General]]
    [yes]
        en = Yes
        es = Sí
        fr = Oui
        ja = はい
    [no]
        en = No
        fr = Non
        ja = いいえ
```

with command `twine generate-string-file strings.txt Localization.strings --lang en`
This is because `StringsRow.matches_tags?` implementation

```
def matches_tags?(tags)                                          
  if @tags == nil || @tags.length == 0                                   
    # This row has no tags. Never match                                     
    return false            
  elsif tags == nil || tags.length == 0                                        
    # The user did not specify any tags. Everything passes.                 
    return true                                                                                                                        
  else                                                                      
    _snip_
end  
```

StringsRow does not contain any tags when parsed strings.txt above. 
So `@tags` is always nil, because of that this method always return false.

This patch only swapped order of evaluation.
