### PR TITLE
Edited Apple formatter to more closely match the Apple-generated format

### DIFF
--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -79,7 +79,7 @@ module Twine
                 if !printed_section
                   f.puts ''
                   if section.name && section.name.length > 0
-                    f.puts "/* #{section.name} */"
+                    f.print "/* #{section.name} */\n\n"
                   end
                   printed_section = true
                 end
@@ -95,13 +95,14 @@ module Twine
                   comment = comment.gsub('*/', '* /')
                 end
 
-                f.print "\"#{key}\" = \"#{value}\";"
                 if comment && comment.length > 0
-                  f.print "  /* #{comment} */\n"
+                  f.print "/* #{comment} */\n"
                 else
                   f.print "\n"
                 end
-              end
+
+                f.print "\"#{key}\" = \"#{value}\";\n\n"
+             end
             end
           end
         end


### PR DESCRIPTION
This patch moves the comment strings to the line directly above each key-value pair, instead of directly after on the same line. This mirror's Apple's genstrings format. Twine should match Apple's format for compatibility with other tools that attempt to parse the string file (e.g., online translation services), as they will expect the comment to precede each kv pair.
