### PR TITLE
CSV Support, Export Untranslated Strings Only for CSV and Multiple langu...

### DIFF
--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -61,6 +61,9 @@ module Twine
         opts.on('-s', '--include-untranslated', 'This flag will cause any Android string files that are generated to include strings that have not yet been translated for the current language.') do |s|
           @options[:include_untranslated] = true
         end
+        opts.on('-y', '--untranslated-only', 'This flag will cause any CSV files that are generated to include only strings that have not yet been translated for the current language.') do |s|
+          @options[:untranslated_only] = true
+        end
         opts.on('-o', '--output-file OUTPUT_FILE', 'Write the new strings database to this file instead of replacing the original file. This flag is only useful when running the consume-string-file or consume-loc-drop commands.') do |o|
           @options[:output_path] = o
         end
@@ -125,9 +128,6 @@ module Twine
           raise Twine::Error.new "Unknown argument: #{@args[3]}"
         else
           raise Twine::Error.new 'Not enough arguments.'
-        end
-        if @options[:languages] and @options[:languages].length > 1
-          raise Twine::Error.new 'Please only specify a single language for the generate-string-file command.'
         end
       when 'generate-all-string-files'
         if ARGV.length == 3

--- a/lib/twine/formatters.rb
+++ b/lib/twine/formatters.rb
@@ -1,12 +1,13 @@
 require 'twine/formatters/abstract'
 require 'twine/formatters/android'
 require 'twine/formatters/apple'
+require 'twine/formatters/csv'
 require 'twine/formatters/flash'
 require 'twine/formatters/gettext'
 require 'twine/formatters/jquery'
 
 module Twine
   module Formatters
-    FORMATTERS = [Formatters::Apple, Formatters::Android, Formatters::Gettext, Formatters::JQuery, Formatters::Flash]
+    FORMATTERS = [Formatters::Apple, Formatters::Android, Formatters::Gettext, Formatters::JQuery, Formatters::Flash, Formatters::Csv]
   end
 end

--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -13,6 +13,10 @@ module Twine
         @options = options
       end
 
+      def can_handle_mutiple_languages?()
+        return false
+      end
+
       def iosify_substitutions(str)
         # 1) use "@" instead of "s" for substituting strings
         str.gsub!(/%([0-9\$]*)s/, '%\1@')

--- a/lib/twine/formatters/csv.rb
+++ b/lib/twine/formatters/csv.rb
@@ -1,0 +1,146 @@
+module Twine
+  module Formatters
+    class Csv < Abstract
+      FORMAT_NAME = 'csv'
+      EXTENSION = '.csv'
+      DEFAULT_FILE_NAME = 'strings.csv'
+
+      def self.can_handle_directory?(path)
+        return false
+      end
+
+      def can_handle_mutiple_languages?()
+        return true
+      end
+
+      def default_file_name
+        return DEFAULT_FILE_NAME
+      end
+
+      def determine_language_given_path(path)
+        return
+      end
+
+      def read_file(path, lang)
+        encoding = Twine::Encoding.encoding_for_path(path)
+        sep = nil
+        if !encoding.respond_to?(:encode)
+          # This code is not necessary in 1.9.3 and does not work as it did in 1.8.7.
+          if encoding.end_with? 'LE'
+            sep = "\x0a\x00"
+          elsif encoding.end_with? 'BE'
+            sep = "\x00\x0a"
+          else
+            sep = "\n"
+          end
+        end
+
+        if encoding.index('UTF-16')
+          mode = "rb:#{encoding}"
+        else
+          mode = "r:#{encoding}"
+        end
+
+        firstLine = true
+
+        File.open(path, mode) do |f|
+          last_comment = nil
+          while line = (sep) ? f.gets(sep) : f.gets
+            if encoding.index('UTF-16')
+              if line.respond_to? :encode!
+                line.encode!('UTF-8')
+              else
+                require 'iconv'
+                line = Iconv.iconv('UTF-8', encoding, line).join
+              end
+            end
+
+            if firstLine
+              firstLine = false
+              fields = line.parse_csv
+            else
+
+              langs = fields.dup
+
+              keyIdx = fields.index('Key')
+              commentIdx = fields.index('Comment')
+              line = line.parse_csv
+
+              key = line[keyIdx]
+              langs.delete_at(keyIdx)
+
+              comment = line[commentIdx]
+              langs.delete_at(commentIdx)
+
+              langs.each do |theLang|
+
+                langIdx = fields.index(theLang)
+
+                if lang.include? theLang
+                  set_translation_for_key(key, theLang, line[langIdx])
+
+                  if @options[:consume_comments]
+                    set_comment_for_key(key, line[commentIdx])
+                  end
+                end
+
+              end
+            end
+          end
+        end
+      end
+
+      def write_file(path, lang)
+        default_lang = @strings.language_codes[0]
+        encoding = @options[:output_encoding] || 'UTF-8'
+        File.open(path, "w:#{encoding}") do |f|
+          f.write "Key,Comment"
+          lang.each do |thelang|
+            f.write ",#{thelang}"
+          end
+          f.write "\n"
+
+          @strings.sections.each do |section|
+            section.rows.each do |row|
+
+              if row.matches_tags?(@options[:tags], @options[:untagged])
+
+                translated = true
+                values = ""
+
+                lang.each do |thelang|
+                  value = row.translated_string_for_lang(thelang, default_lang)
+                  value = value.gsub('"', '\\\\"')
+                  values << ",\"#{value}\""
+
+                  if !row.translated_string_for_lang(thelang, nil)
+                    translated = false
+                  end
+                end
+
+                if !@options[:untranslated_only] || !translated
+
+                  f.write "\"#{row.key}\""
+                  comment = row.comment
+
+                  if comment
+                    comment = comment.gsub('"', '\\\\"')
+                  end
+                  f.write ",\"#{comment}\""
+
+                  lang.each do |thelang|
+                    value = row.translated_string_for_lang(thelang, default_lang)
+                    value = value.gsub('"', '\\\\"')
+                    f.write ",\"#{values}\""
+                  end
+
+                  f.write "\n"
+                end
+              end
+            end
+          end
+        end
+    end
+  end
+end
+end

--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -35,24 +35,25 @@ module Twine
             value = nil
             comment = nil
 
-            comment_match = comment_regex.match(item)
-            if comment_match
-              comment = comment_match[1]
-            end
-            key_match = key_regex.match(item)
-            if key_match
-              key = key_match[1].gsub('\\"', '"')
-            end
-            value_match = value_regex.match(item)
-            if value_match
-              value = value_match[1].gsub(/"\n"/, '').gsub('\\"', '"')
+            for line in item.split(/\r?\n/)
+              comment_match = comment_regex.match(line)
+              if comment_match
+                comment = comment_match[1]
+              end
+              key_match = key_regex.match(line)
+              if key_match
+                key = key_match[1].gsub('\\"', '"')
+              end
+              value_match = value_regex.match(line)
+              if value_match
+                value = value_match[1].gsub('\\"', '"')
+              end
             end
             if key and key.length > 0 and value and value.length > 0
               set_translation_for_key(key, lang, value)
-              if comment and comment.length > 0 and !comment.start_with?("SECTION:")
+              if comment and comment.length > 0
                 set_comment_for_key(key, comment)
               end
-              comment = nil
             end
           end
         end
@@ -67,15 +68,6 @@ module Twine
             printed_section = false
             section.rows.each do |row|
               if row.matches_tags?(@options[:tags], @options[:untagged])
-                if !printed_section
-                  f.puts ''
-                    if section.name && section.name.length > 0
-                      section_name = section.name.gsub('--', '—')
-                      f.puts "# SECTION: #{section_name}"
-                    end
-                  printed_section = true
-                end
-
                 basetrans = row.translated_string_for_lang(default_lang)
 
                 if basetrans

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -54,7 +54,7 @@ module Twine
     def generate_string_file
       lang = nil
       if @options[:languages]
-        lang = @options[:languages][0]
+        lang = @options[:languages]
       end
 
       read_write_string_file(@options[:output_path], false, lang)
@@ -131,6 +131,10 @@ module Twine
       end
       if !lang
         raise Twine::Error.new "Unable to determine language for #{path}"
+      end
+
+      if lang.length > 1 && !formatter.can_handle_mutiple_languages?()
+          raise Twine::Error.new "Please only specify a single language for this format."
       end
 
       if !@strings.language_codes.include? lang

--- a/lib/twine/stringsfile.rb
+++ b/lib/twine/stringsfile.rb
@@ -167,7 +167,7 @@ module Twine
             end
             @language_codes[1..-1].each do |lang|
               value = row.translations[lang]
-              if value
+              if value && value != row.translations[dev_lang]
                 if value[0,1] == ' ' || value[-1,1] == ' ' || (value[0,1] == '`' && value[-1,1] == '`')
                   value = '`' + value + '`'
                 end


### PR DESCRIPTION
Adds CSV Support, I also made it so I can export only the translations I am missing as a CSV. 

I add to tweak the generate-string-file command so it accepts multiple languages. And if a formatter can support multiple languages in one file (Like CSV can) it will put them all in one file else it will complain that it only accepts one language
