### PR TITLE
Exception Fix: Add encoding comment to ensure file is parsed as utf-8

### DIFF
--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module Twine
   module Formatters
     class Gettext < Abstract


### PR DESCRIPTION
Doing a checkout of the current master branch results in an exception being raised from within the gettext formatter:

```
/usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require': /Users/blake/Projects/TripAdvisor/twine/lib/twine/formatters/gettext.rb:73: invalid multibyte char (US-ASCII) (SyntaxError)
/Users/blake/Projects/TripAdvisor/twine/lib/twine/formatters/gettext.rb:73: invalid multibyte char (US-ASCII)
/Users/blake/Projects/TripAdvisor/twine/lib/twine/formatters/gettext.rb:73: syntax error, unexpected $end, expecting ')'
                      section_name = section.name.gsub('--', '—')
                                                                ^
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /Users/blake/Projects/TripAdvisor/twine/lib/twine/formatters.rb:5:in `<top (required)>'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /Users/blake/Projects/TripAdvisor/twine/lib/twine.rb:7:in `<module:Twine>'
    from /Users/blake/Projects/TripAdvisor/twine/lib/twine.rb:1:in `<top (required)>'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /Users/blake/Projects/TripAdvisor/twine/test/twine_test.rb:4:in `<top (required)>'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/site_ruby/1.9.1/rubygems/core_ext/kernel_require.rb:51:in `require'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:4:in `select'
    from /usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib" -I"/usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib" "/usr/local/var/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_test_loader.rb" "test/twine_test.rb" ]

Tasks: TOP => default => test
(See full trace by running task with --trace)
```

The hyphen used on line 73 is a multi-byte character and requires that the file be parsed in UTF-8. This pull requests adds a comment that ensures the encoding is utf-8.
