### PR TITLE
Fix incorrect handling of nested paths when generating string files

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -118,14 +118,18 @@ module Twine
         end
 
         file_name = @options[:file_name] || default_file_name
+        langs_written = []
         Dir.foreach(path) do |item|
-          if File.directory?(item)
-            lang = determine_language_given_path(item)
+          file = File.join(path, item)
+          if File.directory?(file)
+            lang = determine_language_given_path(file)
             if lang
               write_file(File.join(path, item, file_name), lang)
+              langs_written << lang
             end
           end
         end
+        raise Twine::Error.new("Failed to genertate any files: No languages found at #{path}") if langs_written.empty?
       end
     end
   end


### PR DESCRIPTION
When generating strings files, the `write_all_files` method will incorrectly handle relative paths. The `Dir.foreach` check will iterate over subpath of an input directory, but the check to `File.directory?` does not ensure that the item's path is considered with the full relative parent.

This change ensures that valid files are not skipped because they were stripped of their relative parent directory.

I also added an error in the event that zero files are written -- my build process silently produced an invalid app archive because no output or failure was generated despite the fact that Twine didn't actually do any work.
