### PR TITLE
Remove section titles and comments from JSON output

### DIFF
--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -58,9 +58,6 @@ module Twine
               if row.matches_tags?(@options[:tags], @options[:untagged])
                 if !printed_section
                   f.puts ''
-                  if section.name && section.name.length > 0
-                    f.puts "/* #{section.name} */"
-                  end
                   printed_section = true
                 end
 
@@ -77,11 +74,7 @@ module Twine
 
                 f.print "\"#{key}\":\"#{value}\","
 
-                if comment && comment.length > 0
-                  f.print "  /* #{comment} */\n"
-                else
-                  f.print "\n"
-                end
+                f.print "\n"
               end
             end
           end


### PR DESCRIPTION
Similar to my previous commit. The comment syntax is not proper JSON and the standard JavaScript JSON parser can't handle it.

At a glance I can't see what the `printed_section` variable is for so I just let it be. Also a line break will still be printed between sections which is good.
