### PR TITLE
Allow `consume-all-string-files` to apply --tags to newly added translations.  Addresses issue #60.

### DIFF
--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -93,7 +93,7 @@ module Twine
         opts.separator '> twine generate-string-file strings.txt ko.xml --tags FT'
         opts.separator '> twine generate-all-string-files strings.txt Resources/Locales/ --tags FT,FB'
         opts.separator '> twine consume-string-file strings.txt ja.strings'
-        opts.separator '> twine consume-all-string-files strings.txt Resources/Locales/ --developer-language en'
+        opts.separator '> twine consume-all-string-files strings.txt Resources/Locales/ --developer-language en --tags DefaultTag1,DefaultTag2'
         opts.separator '> twine generate-loc-drop strings.txt LocDrop5.zip --tags FT,FB --format android --lang de,en,en-GB,ja,ko'
         opts.separator '> twine consume-loc-drop strings.txt LocDrop5.zip'
         opts.separator '> twine generate-report strings.txt'

--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -66,7 +66,7 @@ module Twine
           return str
         end
       end
-
+      
       def set_translation_for_key(key, lang, value)
         if @strings.strings_map.include?(key)
           @strings.strings_map[key].translations[lang] = value
@@ -80,6 +80,11 @@ module Twine
           end
           current_row = StringsRow.new(key)
           current_section.rows << current_row
+          
+          if @options[:tags] && @options[:tags].length > 0
+              current_row.tags = @options[:tags]            
+          end
+          
           @strings.strings_map[key] = current_row
           @strings.strings_map[key].translations[lang] = value
         else
@@ -133,7 +138,7 @@ module Twine
           end
         end
         if langs_written.empty?
-          raise Twine::Error.new("Failed to genertate any files: No languages found at #{path}")
+          raise Twine::Error.new("Failed to generate any files: No languages found at #{path}")
         end
       end
     end


### PR DESCRIPTION
Allow `consume-all-string-files` to apply --tags to newly added translations. Addresses issue #60.
