### PR TITLE
Abort on error

### DIFF
--- a/bin/twine
+++ b/bin/twine
@@ -3,6 +3,5 @@ require 'twine'
 begin
   Twine::Runner.run(ARGV)
 rescue Twine::Error => e
-  STDERR.puts e.message
-  exit
+  abort e.message
 end


### PR DESCRIPTION
This ensures the exit status 1, which is useful in scripts.
