### PR TITLE
Allow specifying `section` during `consume-localization-file`

### DIFF
--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -66,6 +66,10 @@ module Twine
         DESC
         default: :all
       },
+      :section => {
+        switch: ['-i', '--section SECTION'],
+        description: 'Appy the specified section to use when consuming a localization file.'
+      },
       languages: {
         switch: ['-l', '--lang LANGUAGES', Array],
         description: 'Comma separated list of language codes to use for the specified action.'
@@ -164,7 +168,8 @@ module Twine
           :format,
           :languages,
           :output_path,
-          :tags
+          :tags,
+          :section,
         ],
         option_validation: Proc.new { |options|
           if options[:languages] and options[:languages].length > 1

--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -27,7 +27,7 @@ module Twine
         raise NotImplementedError.new("You must implement default_file_name in your formatter class.")
       end
 
-      def set_translation_for_key(key, lang, value)
+      def set_translation_for_key(key, lang, value, section_name = 'Uncategorized')
         value = value.gsub("\n", "\\n")
 
         if @twine_file.definitions_by_key.include?(key)
@@ -39,9 +39,9 @@ module Twine
           end
         elsif @options[:consume_all]
           Twine::stderr.puts "Adding new definition '#{key}' to twine file."
-          current_section = @twine_file.sections.find { |s| s.name == 'Uncategorized' }
+          current_section = @twine_file.sections.find { |s| s.name == section_name }
           unless current_section
-            current_section = TwineSection.new('Uncategorized')
+            current_section = TwineSection.new(section_name)
             @twine_file.sections.insert(0, current_section)
           end
           current_definition = TwineDefinition.new(key)

--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -27,7 +27,7 @@ module Twine
         raise NotImplementedError.new("You must implement default_file_name in your formatter class.")
       end
 
-      def set_translation_for_key(key, lang, value, section_name = 'Uncategorized')
+      def set_translation_for_key(key, lang, value, section_name = @options[:section] || 'Uncategorized')
         value = value.gsub("\n", "\\n")
 
         if @twine_file.definitions_by_key.include?(key)

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -65,21 +65,9 @@ module Twine
           elsif child.is_a? REXML::Element
             next unless child.name == 'string'
             next if child.attributes['translatable'].to_s == 'false'
-            
-            child_text = child.text
-            if child.has_elements? 
-              children_string = String.new
-              child.children.each do |sub|
-                next unless sub_text = sub.get_text
-                children_string += sub_text.to_s
-              end
-              child_text = children_string
-            end
-            
             key = child.attributes['name']
 
-        
-            set_translation_for_key(key, lang, child_text)
+            set_translation_for_key(key, lang, child.text)
             set_comment_for_key(key, comment) if comment
 
             comment = nil

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -64,10 +64,20 @@ module Twine
             comment = content if content.length > 0 and not content.start_with?("SECTION:")
           elsif child.is_a? REXML::Element
             next unless child.name == 'string'
-
+            child_text = child.text
+            if child.has_elements? 
+              children_string = String.new
+              child.children.each do |sub|
+                next unless sub_text = sub.get_text
+                children_string += sub_text.to_s
+              end
+              child_text = children_string
+            end
+            
             key = child.attributes['name']
 
-            set_translation_for_key(key, lang, child.text)
+        
+            set_translation_for_key(key, lang, child_text)
             set_comment_for_key(key, comment) if comment
 
             comment = nil

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -64,6 +64,8 @@ module Twine
             comment = content if content.length > 0 and not content.start_with?("SECTION:")
           elsif child.is_a? REXML::Element
             next unless child.name == 'string'
+            next if child.attributes['translatable'].to_s == 'false'
+            
             child_text = child.text
             if child.has_elements? 
               children_string = String.new

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -45,7 +45,7 @@ module Twine
       end
 
       def set_translation_for_key(key, lang, value)
-        value = CGI.unescapeHTML(value)
+        value = CGI.unescapeHTML((value.nil? || value.empty?) ? "" : value)
         value.gsub!('\\\'', '\'')
         value.gsub!('\\"', '"')
         value = convert_placeholders_from_android_to_twine(value)

--- a/lib/twine/version.rb
+++ b/lib/twine/version.rb
@@ -1,3 +1,3 @@
 module Twine
-  VERSION = '0.10.1'
+  VERSION = '0.10.2'
 end

--- a/lib/twine/version.rb
+++ b/lib/twine/version.rb
@@ -1,3 +1,3 @@
 module Twine
-  VERSION = '0.10.2'
+  VERSION = '0.10.1'
 end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -62,6 +62,12 @@ class CLITest < TwineTest
     assert_equal random_languages.sort, @options[:languages].sort
   end
 
+  def assert_option_section
+    section = "section"
+    parse_with "--section #{section}"
+    assert_equal [section], @options[:section]
+  end
+
   def assert_option_languages
     assert_option_single_language
     assert_option_multiple_languages


### PR DESCRIPTION
I'm using Twine to manage strings for Storyboards in iOS. When using `consume-localization-file`,  I'd like to be able to specify a section.

Example usage:
`twine consume-localization-file ${twine_location} Storyboard.strings --consume-all --section ${section}`

I've little experience with Ruby so I'm not sure if you need additional tests, would appreciate some comments.

Thanks!