### PR TITLE
CSV formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Twine currently supports the following output formats:
 * [Django PO Files][djangopo] (format: django)
 * [Tizen String Resources][tizen] (format: tizen)
 * [Flash/Flex Properties][flash] (format: flash)
+* [Comma-separated values (CSV)][csv] (format: csv)
 
 If you would like to enable Twine to create localization files in another format, read the wiki page on how to create an appropriate formatter.
 
@@ -229,4 +230,5 @@ Many thanks to all of the contributors to the Twine project, including:
 [djangopo]: https://docs.djangoproject.com/en/dev/topics/i18n/translation/
 [tizen]: https://developer.tizen.org/documentation/articles/localization
 [flash]: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/mx/resources/IResourceManager.html#getString()
+[csv]: http://en.wikipedia.org/wiki/Comma-separated_values
 [printf]: https://en.wikipedia.org/wiki/Printf_format_string

--- a/lib/twine.rb
+++ b/lib/twine.rb
@@ -31,6 +31,7 @@ module Twine
   require 'twine/formatters/abstract'
   require 'twine/formatters/android'
   require 'twine/formatters/apple'
+  require 'twine/formatters/csv'
   require 'twine/formatters/django'
   require 'twine/formatters/flash'
   require 'twine/formatters/gettext'

--- a/lib/twine/formatters/csv.rb
+++ b/lib/twine/formatters/csv.rb
@@ -1,0 +1,64 @@
+require 'csv'
+
+module Twine
+  module Formatters
+    class CSV < Abstract
+      def format_name
+        'CSV'
+      end
+
+      def extension
+        '.csv'
+      end
+
+      def default_file_name
+        'strings.csv'
+      end
+
+      def determine_language_given_path(path)
+        path_arr = path.split(File::SEPARATOR)
+        path_arr.each do |segment|
+          match = /-(.+)\.csv$/.match(segment)
+          return match[1] if match
+        end
+
+        return
+      end
+
+      def read(io, lang)
+        while line = io.gets
+          fields = ::CSV.parse_line(line)
+
+          key = fields[0]
+          value = fields[1]
+          comment = fields[2]
+
+          # checks for nil, empty and whitespace
+          if key =~ /\S/ and value =~ /\S/
+            set_translation_for_key(key, lang, value)
+            set_comment_for_key(key, comment) if comment =~ /\S/
+          end
+        end
+      end
+
+      def format_header(lang)
+        'Key,Value,Comment'
+      end
+
+      def format_section(section, lang)
+        # removes newline above section
+        super.strip
+      end
+
+      def format_definition(definition, lang)
+        key = definition.key
+        value = definition.translation_for_lang(lang)
+        comment = definition.comment
+
+        ::CSV.generate_line([key, value, comment], row_sep: '', force_quotes: true)
+      end
+    end
+  end
+end
+
+Twine::Formatters.formatters << Twine::Formatters::CSV.new

--- a/lib/twine/formatters/csv.rb
+++ b/lib/twine/formatters/csv.rb
@@ -46,8 +46,8 @@ module Twine
       end
 
       def format_section(section, lang)
-        # removes newline above section
-        super.strip
+        # removes empty lines
+        super.gsub(/^$\n/, '')
       end
 
       def format_definition(definition, lang)
@@ -55,7 +55,7 @@ module Twine
         value = definition.translation_for_lang(lang)
         comment = definition.comment
 
-        ::CSV.generate_line([key, value, comment], row_sep: '', force_quotes: true)
+        ::CSV.generate_line([key, value, comment], row_sep: '')
       end
     end
   end

--- a/test/fixtures/formatter_csv.csv
+++ b/test/fixtures/formatter_csv.csv
@@ -1,5 +1,5 @@
 Key,Value,Comment
-"key1","value1-english","comment key1"
-"key2","value2-english",""
-"key3","value3-english",""
-"key4","value4-english","comment key4"
+key1,value1-english,comment key1
+key2,value2-english,
+key3,value3-english,
+key4,value4-english,comment key4

--- a/test/fixtures/formatter_csv.csv
+++ b/test/fixtures/formatter_csv.csv
@@ -1,0 +1,5 @@
+Key,Value,Comment
+"key1","value1-english","comment key1"
+"key2","value2-english",""
+"key3","value3-english",""
+"key4","value4-english","comment key4"

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -229,6 +229,25 @@ class TestAppleFormatter < FormatterTest
   end
 end
 
+class TestCSVFormatter < FormatterTest
+
+  def setup
+    super Twine::Formatters::CSV
+  end
+
+  def test_read_format
+    @formatter.read content_io('formatter_csv.csv'), 'en'
+
+    assert_translations_read_correctly
+  end
+
+  def test_format_file
+    formatter = Twine::Formatters::CSV.new
+    formatter.twine_file = @twine_file
+    assert_equal content('formatter_csv.csv'), formatter.format_file('en')
+  end
+end
+
 class TestJQueryFormatter < FormatterTest
 
   def setup


### PR DESCRIPTION
Yet Another Try at adding a CSV formatter (related: #34, #41, #154).

I went for a barebones formatter, opting out of creating a convention for encoding multiple languages in one CSV file. The format is similar to Apple's `.strings` except that language information is encoded in the file name:

- `strings-en.csv`
- `strings-ro.csv`
- etc.

Here's some sample CSV, pulled out from the test fixtures:
```csv
Key,Value,Comment
key1,value1-english,comment key1
key2,value2-english,
key3,value3-english,
key4,value4-english,comment key4
```

I was a little confused about where exactly I should be adding tests. Just let me know what I should fix and I'll jump on it!