### PR TITLE
Setup continuous integration with Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,28 @@
+machine:
+  environment:
+    BUNDLE_INSTALL_PATH: "./vendor/bundle" # circle caches this by default
+    TEST_RUBIES: "system 2.1 2.2 2.3"
+  xcode:
+    version: "8.2"
+
+dependencies:
+  override:
+    - >
+      for v in $TEST_RUBIES; do
+        echo
+        echo "****************************************"
+        echo "Installing gems on Ruby version: $v"
+        echo "****************************************"
+        chruby-exec $v -- bundle install --path $BUNDLE_INSTALL_PATH
+      done
+
+test:
+  override:
+    - >
+      for v in $TEST_RUBIES; do
+        echo
+        echo "*******************************"
+        echo "Testing on Ruby version: $v"
+        echo "********************************"
+        chruby-exec $v -- bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
+      done

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
   s.add_development_dependency('rake', "~> 10.4")
   s.add_development_dependency('minitest', "~> 5.5")
+  s.add_development_dependency('minitest-ci', "~> 3.0")
   s.add_development_dependency('mocha', "~> 1.1")
 
   s.executables  = %w( twine )


### PR DESCRIPTION
- Test on multiple rubies: `system (2.0.0), 2.1.*, 2.2.*, 2.3.*`
- Runs builds on macOS in preperation for Xcode integration testing  (#186)

This was quite easy to set up (and hopefully equally easy to understand) as `minitest` is well supported by [CircleCI](https://circleci.com).

Note that this PR won't work immediately on merge, because 1) I don't have permissions to set up a CircleCI for this repo and 2) an admin will need to contact billing@circleci.com to get on their seed tier of the OS X plan which is free for OSS projects: https://circleci.com/pricing/#faq-section-os-x (I expect the process to be super quick).

You can see the CI in action at [teespring/twine](https://github.com/teespring/twine) by clicking the CircleCI shield. (I've merged this branch into our fork's master, and added an additional commit to add the badge — we can do this here after Circle is configured)

Happy to receive feedback and offer explanations.
