### PR TITLE
Add 'q' placeholder modifier for android strings

### DIFF
--- a/lib/twine/placeholders.rb
+++ b/lib/twine/placeholders.rb
@@ -3,7 +3,7 @@ module Twine
     extend self
 
     # Note: the ` ` (single space) flag is NOT supported
-    PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH = '([-+0#])?(\d+|\*)?(\.(\d+|\*))?(hh?|ll?|L|z|j|t)?'
+    PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH = '([-+0#])?(\d+|\*)?(\.(\d+|\*))?(hh?|ll?|L|z|j|t|q)?'
     PLACEHOLDER_PARAMETER_FLAGS_WIDTH_PRECISION_LENGTH = '(\d+\$)?' + PLACEHOLDER_FLAGS_WIDTH_PRECISION_LENGTH
     PLACEHOLDER_TYPES = '[diufFeEgGxXoscpaA]'
 


### PR DESCRIPTION
Fixes #194. I know there is no `q` option in [Android documentation](https://developer.android.com/reference/java/util/Formatter.html), but it was found in our big application, and could be found in others.