### PR TITLE
CocoaPods podspec file added

### DIFF
--- a/twine.podspec
+++ b/twine.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+
+  s.name         = "twine"
+  s.version      = "0.10.1"
+  s.summary      = "Twine is a command line tool for managing your strings and their translations."
+
+  s.description  = <<-DESC
+    Twine is a command line tool for managing your strings and their translations.
+    These are all stored in a master text file and then Twine uses this file to import and export localization files in a variety of types, 
+    including iOS and Mac OS X .strings files, Android .xml files, gettext .po files, and jquery-localize .json files. 
+    This allows individuals and companies to easily share translations across multiple projects, as well as export localization files in any format the user wants.
+  DESC
+
+  s.homepage     = "https://github.com/scelis/twine"
+
+  s.license      = { :type => "BSD", :file => "LICENSE" }
+
+  s.author             = "Sebastian Celis"
+
+  s.source       = { :http => "https://github.com/scelis/twine/archive/v#{s.version}.zip" }
+
+  s.preserve_paths = "*"
+
+end


### PR DESCRIPTION
Thanks for this awesome tool! It would be nice to be able to use twine via CocoaPods. I added basic podspec file in this pull request. 

To publish it via CocoaPods there are two remaining steps:
1. The owner of the repo should register himself and confirm via link in the email he receive:
`pod trunk register your@email.com “Sebastian Celis”`
2. Push the podspec:
`pod trunk push twine.podspec`

https://guides.cocoapods.org/making/getting-setup-with-trunk