### PR TITLE
Fix language detection for .po formatters

### DIFF
--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -16,7 +16,7 @@ module Twine
       def determine_language_given_path(path)
         path_arr = path.split(File::SEPARATOR)
         path_arr.each do |segment|
-          match = /(..)\.po$/.match(segment)
+          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
           return match[1] if match
         end
         

--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -18,10 +18,8 @@ module Twine
       def determine_language_given_path(path)
         path_arr = path.split(File::SEPARATOR)
         path_arr.each do |segment|
-          match = /(..)\.po$/.match(segment)
-          if match
-            return match[1]
-          end
+          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
+          return match[1] if match
         end
 
         return

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -267,7 +267,6 @@ class TestJQueryFormatter < FormatterTest
 end
 
 class TestGettextFormatter < FormatterTest
-
   def setup
     super Twine::Formatters::Gettext
   end
@@ -290,6 +289,10 @@ class TestGettextFormatter < FormatterTest
     assert_equal content('formatter_gettext.po'), formatter.format_file('en')
   end
 
+  def test_deducts_language_and_region
+    language = "en-GB"
+    assert_equal language, @formatter.determine_language_given_path("#{language}.po")
+  end
 end
 
 class TestTizenFormatter < FormatterTest
@@ -328,6 +331,11 @@ class TestDjangoFormatter < FormatterTest
     formatter = Twine::Formatters::Django.new
     formatter.twine_file = @twine_file
     assert_equal content('formatter_django.po'), formatter.format_file('en')
+  end
+
+  def test_deducts_language_and_region
+    language = "en-GB"
+    assert_equal language, @formatter.determine_language_given_path("#{language}.po")
   end
 end
 


### PR DESCRIPTION
The old regular expressions were only supporting two character language
identifiers. This commit allows languages to scale to things like
"en-GB".

Fixes #199