### PR TITLE
Fail twine commands if there’s more than one formatter candidate

### DIFF
--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -282,8 +282,13 @@ module Twine
     end
 
     def find_formatter(&block)
-      formatter = Formatters.formatters.find &block
-      return nil unless formatter
+      formatters = Formatters.formatters.select &block
+      if formatters.empty?
+        return nil
+      elsif formatters.size > 1
+        raise Twine::Error.new("Unable to determine format. Candidates are: #{formatters.map(&:format_name).join(', ')}. Please specify the format you want using '--format'")
+      end
+      formatter = formatters.first
       formatter.twine_file = @twine_file
       formatter.options = @options
       formatter

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -1,13 +1,13 @@
 require 'twine_test'
 
 class CommandTest < TwineTest
-  def prepare_mock_formatter(formatter_class)
+  def prepare_mock_formatter(formatter_class, clear_other_formatters = true)
     twine_file = Twine::TwineFile.new
     twine_file.language_codes.concat KNOWN_LANGUAGES
 
     formatter = formatter_class.new
     formatter.twine_file = twine_file
-    Twine::Formatters.formatters.clear
+    Twine::Formatters.formatters.clear if clear_other_formatters
     Twine::Formatters.formatters << formatter
     formatter
   end

--- a/test/test_generate_localization_file.rb
+++ b/test/test_generate_localization_file.rb
@@ -41,6 +41,24 @@ class TestGenerateLocalizationFile < CommandTest
     new_runner('fr', 'fr.po').generate_localization_file
   end
 
+  def test_deducts_django_format_from_output_path
+    prepare_mock_format_file_formatter Twine::Formatters::Django
+
+    new_runner('fr', 'fr.po').generate_localization_file
+  end
+
+  def test_returns_error_for_ambiguous_output_path
+    # both Gettext and Django use .po
+    gettext_formatter = prepare_mock_formatter(Twine::Formatters::Gettext)
+    gettext_formatter.stubs(:format_file).returns(true)
+    django_formatter = prepare_mock_formatter(Twine::Formatters::Django, false)
+    django_formatter.stubs(:format_file).returns(true)
+
+    assert_raises Twine::Error do
+      new_runner('fr', 'fr.po').generate_localization_file
+    end
+  end
+
   def test_deducts_language_from_output_path
     random_language = KNOWN_LANGUAGES.sample
     formatter = prepare_mock_formatter Twine::Formatters::Android


### PR DESCRIPTION
Fixes #201.

I had to slightly adjust your suggested error message because it's not clear to the method in question which attribute is being checked.