### PR TITLE
Android: Allow basic styling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,12 @@
+# Upcoming Version
+- Preserve basic HTML styling for Android strings (#212)
+- Bugfix: `twine --version` reports "unknown" (#213)
+- Fail twine commands if there's more than one formatter candidate (#201)
+- Support spaces in command line arguments (#206)
+- Bugfix: 'r' missing before region code in Android output folder (#203)
+- Bugfix: .po formatter language detection (#199)
+- Add 'q' placeholder for android strings (#194)
+- Bugfix: Boolean command line parameters are always true (#191)
+
+# 0.10.1
+- Bugfix: Xcode integration (#184)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Twine currently supports the following output formats:
 
 * [iOS and OS X String Resources][applestrings] (format: apple)
 * [Android String Resources][androidstrings] (format: android)
+    * Supports [basic styling][androidstyling] with \<b\>, \<i\>, \<u\> and \<a\> links. These tags will *not* be escaped. Use [`getText()`](https://developer.android.com/reference/android/content/res/Resources.html#getText(int)) to read these strings. Also tags inside `<![CDATA[` won't be escaped. See [\#212](https://github.com/scelis/twine/issues/212) for details.
 * [Gettext PO Files][gettextpo] (format: gettext)
 * [jquery-localize Language Files][jquerylocalize] (format: jquery)
 * [Django PO Files][djangopo] (format: django)
@@ -212,6 +213,7 @@ Many thanks to all of the contributors to the Twine project, including:
 [INI]: http://en.wikipedia.org/wiki/INI_file
 [applestrings]: http://developer.apple.com/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html
 [androidstrings]: http://developer.android.com/guide/topics/resources/string-resource.html
+[androidstyling]: http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling
 [gettextpo]: http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/PO-Files.html
 [jquerylocalize]: https://github.com/coderifous/jquery-localize
 [djangopo]: https://docs.djangoproject.com/en/dev/topics/i18n/translation/

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -45,8 +45,27 @@ class TestAndroidFormatter < FormatterTest
       'this < that'               => 'this &lt; that',
       "it's complicated"          => "it\\'s complicated",
       'a "good" way'              => 'a \"good\" way',
-      '<b>bold</b>'               => '&lt;b>bold&lt;/b>',
-      '<a href="target">link</a>' => '&lt;a href=\"target\">link&lt;/a>',
+
+      '<b>bold</b>'               => '<b>bold</b>',
+      '<i>italic</i>'             => '<i>italic</i>',
+      '<u>underline</u>'          => '<u>underline</u>',
+
+      '<span>inline</span>'       => '&lt;span>inline&lt;/span>',
+      '<p>paragraph</p>'          => '&lt;p>paragraph&lt;/p>',
+
+      '<a href="target">link</a>'     => '<a href="target">link</a>',
+      '<a href="target">"link"</a>'   => '<a href="target">\"link\"</a>',
+      '<a href="target"></a>"out"'    => '<a href="target"></a>\"out\"',
+      '<a href="http://url.com?param=1&param2=3&param3=%20">link</a>'   =>   '<a href="http://url.com?param=1&param2=3&param3=%20">link</a>',
+
+      '<p>escaped</p><![CDATA[]]>'    => '&lt;p>escaped&lt;/p><![CDATA[]]>',
+      '<![CDATA[]]><p>escaped</p>'    => '<![CDATA[]]>&lt;p>escaped&lt;/p>',
+      '<![CDATA[<p>unescaped</p>]]>'  => '<![CDATA[<p>unescaped</p>]]>',
+      '<![CDATA[]]><![CDATA[<p>unescaped</p>]]>'  => '<![CDATA[]]><![CDATA[<p>unescaped</p>]]>',
+
+      '<![CDATA[&]]>'  => '<![CDATA[&]]>',
+      '<![CDATA[\']]>' => '<![CDATA[\']]>',
+      '<![CDATA["]]>'  => '<![CDATA["]]>',
 
       '<xliff:g></xliff:g>' => '<xliff:g></xliff:g>',
       '<xliff:g>untouched</xliff:g>' => '<xliff:g>untouched</xliff:g>',


### PR DESCRIPTION
I tried to follow our [discussion](https://github.com/scelis/twine/issues/204#issuecomment-322133849) and split up the regexp magic to make it easier to follow. @scelis do you think this is good enough? Any further suggestions?