### PR TITLE
use developer-language option for apple Base folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 *.lock
 .ruby-version
+.DS_Store

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -22,10 +22,11 @@ module Twine
         path_arr.each do |segment|
           match = /^(.+)\.lproj$/.match(segment)
           if match
-            if match[1] != "Base"
+            if match[1] == "Base"
+              return @options[:developer_language]
+            else
               return match[1]
             end
-            return @options[:developer_language]
           end
         end
 

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -25,6 +25,7 @@ module Twine
             if match[1] != "Base"
               return match[1]
             end
+            return @options[:developer_language]
           end
         end
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -19,7 +19,7 @@ class FormatterTest < TwineTest
     @empty_twine_file = Twine::TwineFile.new
     @formatter = formatter_class.new
     @formatter.twine_file = @empty_twine_file
-    @formatter.options = { consume_all: true, consume_comments: true }
+    @formatter.options = { consume_all: true, consume_comments: true, developer_language: 'en' }
   end
 
   def assert_translations_read_correctly
@@ -39,7 +39,7 @@ end
 class TestAndroidFormatter < FormatterTest
   def setup
     super Twine::Formatters::Android
-    
+
     @escape_test_values = {
       'this & that'               => 'this &amp; that',
       'this < that'               => 'this &lt; that',
@@ -191,6 +191,16 @@ class TestAppleFormatter < FormatterTest
     @formatter.read content_io('formatter_apple.strings'), 'en'
 
     assert_file_contents_read_correctly
+  end
+
+  def test_deducts_language_from_resource_folder
+    language = %w(en de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("#{language}.lproj/Localizable.strings")
+  end
+
+  def test_deducts_base_language_from_resource_folder
+    #from options developer_language = 'en'
+    assert_equal 'en', @formatter.determine_language_given_path('Base.lproj/Localizations.strings')
   end
 
   def test_reads_quoted_keys

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -19,7 +19,7 @@ class FormatterTest < TwineTest
     @empty_twine_file = Twine::TwineFile.new
     @formatter = formatter_class.new
     @formatter.twine_file = @empty_twine_file
-    @formatter.options = { consume_all: true, consume_comments: true, developer_language: 'en' }
+    @formatter.options = { consume_all: true, consume_comments: true }
   end
 
   def assert_translations_read_correctly
@@ -199,7 +199,7 @@ class TestAppleFormatter < FormatterTest
   end
 
   def test_deducts_base_language_from_resource_folder
-    #from options developer_language = 'en'
+    @formatter.options = { consume_all: true, consume_comments: true, developer_language: 'en' }
     assert_equal 'en', @formatter.determine_language_given_path('Base.lproj/Localizations.strings')
   end
 


### PR DESCRIPTION
Today when we use the consume-all-localization-files command, Base folder is ignored. It should not be ignored when we specify a developer-language (Base.lproj is the fallback language, in the language set as the "developer language" in Xcode).