### PR TITLE
Order of definition elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next version
+
+- Feature: Definitions in Twine file are ordered comment, tags, reference key, developer language translation, other translations (#227)
+
 # 1.0.1 (2017-10-17)
 
 - Bugfix: Always prefer the passed-in formatter (#221)

--- a/lib/twine/twine_file.rb
+++ b/lib/twine/twine_file.rb
@@ -188,20 +188,20 @@ module Twine
           section.definitions.each do |definition|
             f.puts "\t[#{definition.key}]"
 
-            value = write_value(definition, dev_lang, f)
-            if !value && !definition.reference_key
-              puts "Warning: #{definition.key} does not exist in developer language '#{dev_lang}'"
-            end
-            
-            if definition.reference_key
-              f.puts "\t\tref = #{definition.reference_key}"
+            if definition.raw_comment and definition.raw_comment.length > 0
+              f.puts "\t\tcomment = #{definition.raw_comment}"
             end
             if definition.tags && definition.tags.length > 0
               tag_str = definition.tags.join(',')
               f.puts "\t\ttags = #{tag_str}"
             end
-            if definition.raw_comment and definition.raw_comment.length > 0
-              f.puts "\t\tcomment = #{definition.raw_comment}"
+            if definition.reference_key
+              f.puts "\t\tref = #{definition.reference_key}"
+            end
+
+            value = write_value(definition, dev_lang, f)
+            if !value && !definition.reference_key
+              puts "Warning: #{definition.key} does not exist in developer language '#{dev_lang}'"
             end
             @language_codes[1..-1].each do |lang|
               write_value(definition, lang, f)


### PR DESCRIPTION
#227 was too easy _not_ to implement ;-)

Currently a twine definition looks like this

```ini
[[Section 1]]
	[key1]
		en = value1-english
		tags = tag1
		comment = comment key1
		fa = value1-persian
```

and the order the elements go in is

1. developer language translation
1. reference key
1. tags
1. comment
1. other translations

After this PR a definition looks like

```ini
[[Section 1]]
	[key1]
		comment = comment key1
		tags = tag1
		en = value1-english
		fa = value1-persian
```

and the order is

1. comment
1. tags
1. reference key
1. developer language translation
1. other translations

which is more logical and easier to follow for a human reader. It also shouldn't break any existing scripts, because the order of elements in an INI file doesn't matter.