### PR TITLE
Fix safe yaml crash

### DIFF
--- a/lib/twine/plugin.rb
+++ b/lib/twine/plugin.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'safe_yaml/load'
 
 SafeYAML::OPTIONS[:suppress_warnings] = true


### PR DESCRIPTION
Fix Safe Yaml crash

In some cases safe yaml will be loaded and cause it to crash when ever it is run before date class has been loaded. This can be seen in a few cases and makes it crash when ever twine is called. 

https://github.com/dtao/safe_yaml/issues/80
https://github.com/test-kitchen/test-kitchen/issues/1327
https://github.com/jekyll/jekyll/issues/3201

This commit fixes that issue