### PR TITLE
Language deduction

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -3,6 +3,8 @@ require 'fileutils'
 module Twine
   module Formatters
     class Abstract
+      LANGUAGE_CODE_WITH_OPTIONAL_REGION_CODE = "[a-z]{2}(?:-[A-Za-z]{2})?"
+
       attr_accessor :twine_file
       attr_accessor :options
 
@@ -76,7 +78,11 @@ module Twine
       end
 
       def determine_language_given_path(path)
-        raise NotImplementedError.new("You must implement determine_language_given_path in your formatter class.")
+        only_language_and_region = /^#{LANGUAGE_CODE_WITH_OPTIONAL_REGION_CODE}$/i
+        basename = File.basename(path, File.extname(path))
+        return basename if basename =~ only_language_and_region
+        
+        path.split(File::SEPARATOR).reverse.find { |segment| segment =~ only_language_and_region }
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -37,7 +37,7 @@ module Twine
           end
         end
 
-        return
+        return super
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -30,7 +30,7 @@ module Twine
           end
         end
 
-        return
+        return super
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -13,16 +13,6 @@ module Twine
         'strings.po'
       end
 
-      def determine_language_given_path(path)
-        path_arr = path.split(File::SEPARATOR)
-        path_arr.each do |segment|
-          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
-          return match[1] if match
-        end
-        
-        return
-      end
-
       def read(io, lang)
         comment_regex = /#\. *"?(.*)"?$/
         key_regex = /msgid *"(.*)"$/

--- a/lib/twine/formatters/flash.rb
+++ b/lib/twine/formatters/flash.rb
@@ -15,11 +15,6 @@ module Twine
         'resources.properties'
       end
 
-      def determine_language_given_path(path)
-        # match two-letter language code, optionally followed by a two letter region code
-        path.split(File::SEPARATOR).reverse.find { |segment| segment =~ /^([a-z]{2}(-[a-z]{2})?)$/i }
-      end
-
       def set_translation_for_key(key, lang, value)
         value = convert_placeholders_from_flash_to_twine(value)
         super(key, lang, value)

--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -55,7 +55,7 @@ module Twine
       end
 
       def format_header(lang)
-        "msgid \"\"\nmsgstr \"\"\n\"Language: #{lang}\\n\"\n\"X-Generator: Twine #{Twine::VERSION}\\n\"\n"
+        "msgid \"\"\nmsgstr \"\"\n\"Language: #{lang}\"\n\"X-Generator: Twine #{Twine::VERSION}\"\n"
       end
 
       def format_section_header(section)

--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -15,16 +15,6 @@ module Twine
         'strings.po'
       end
 
-      def determine_language_given_path(path)
-        path_arr = path.split(File::SEPARATOR)
-        path_arr.each do |segment|
-          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
-          return match[1] if match
-        end
-
-        return
-      end
-
       def read(io, lang)
         comment_regex = /#.? *"(.*)"$/
         key_regex = /msgctxt *"(.*)"$/

--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -14,22 +14,17 @@ module Twine
       end
 
       def determine_language_given_path(path)
-        path_arr = path.split(File::SEPARATOR)
-        path_arr.each do |segment|
-          match = /^((.+)-)?([^-]+)\.json$/.match(segment)
-          if match
-            return match[3]
-          end
-        end
+        match = /^.+-([^-]{2})\.json$/.match File.basename(path)
+        return match[1] if match
 
-        return
+        return super
       end
 
       def read(io, lang)
         begin
           require "json"
         rescue LoadError
-          raise Twine::Error.new "You must run 'gem install json' in order to read or write jquery-localize files."
+          raise Twine::Error.new "You must run `gem install json` in order to read or write jquery-localize files."
         end
 
         json = JSON.load(io)

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -294,11 +294,6 @@ module Twine
       end
     end
 
-    def determine_language_given_path(path)
-      code = File.basename(path, File.extname(path))
-      return code if @twine_file.language_codes.include? code
-    end
-
     def formatter_for_format(format)
       find_formatter { |f| f.format_name == format }
     end
@@ -342,7 +337,7 @@ module Twine
         raise Twine::Error.new "Unable to determine format of #{path}"
       end      
 
-      lang = lang || determine_language_given_path(path) || formatter.determine_language_given_path(path)
+      lang = lang || formatter.determine_language_given_path(path)
       unless lang
         raise Twine::Error.new "Unable to determine language for #{path}"
       end

--- a/test/fixtures/formatter_gettext.po
+++ b/test/fixtures/formatter_gettext.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"Language: en\n"
-"X-Generator: Twine <%= Twine::VERSION %>\n"
+"Language: en"
+"X-Generator: Twine <%= Twine::VERSION %>"
 
 
 # SECTION: Section 1

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -180,8 +180,13 @@ class TestAndroidFormatter < FormatterTest
     assert_equal identifier, @formatter.format_value(identifier)
   end
 
+  def test_deducts_language_from_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("#{language}.xml")
+  end
+
   def test_deducts_language_from_resource_folder
-    language = %w(en de fr).sample
+    language = KNOWN_LANGUAGES.sample
     assert_equal language, @formatter.determine_language_given_path("res/values-#{language}")
   end
 
@@ -211,6 +216,11 @@ class TestAppleFormatter < FormatterTest
     @formatter.read content_io('formatter_apple.strings'), 'en'
 
     assert_file_contents_read_correctly
+  end
+
+  def test_deducts_language_from_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("#{language}.strings")
   end
 
   def test_deducts_language_from_resource_folder
@@ -317,6 +327,21 @@ class TestJQueryFormatter < FormatterTest
   def test_format_value_with_newline
     assert_equal "value\nwith\nline\nbreaks", @formatter.format_value("value\nwith\nline\nbreaks")
   end
+
+  def test_deducts_language_from_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("#{language}.json")
+  end
+
+  def test_deducts_language_from_extended_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("something-#{language}.json")
+  end
+
+  def test_deducts_language_from_path
+    language = %w(en-GB de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
+  end
 end
 
 class TestGettextFormatter < FormatterTest
@@ -346,6 +371,11 @@ class TestGettextFormatter < FormatterTest
     language = "en-GB"
     assert_equal language, @formatter.determine_language_given_path("#{language}.po")
   end
+
+  def test_deducts_language_from_path
+    language = %w(en-GB de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
+  end
 end
 
 class TestTizenFormatter < FormatterTest
@@ -366,7 +396,6 @@ class TestTizenFormatter < FormatterTest
     formatter.twine_file = @twine_file
     assert_equal content('formatter_tizen.xml'), formatter.format_file('en')
   end
-
 end
 
 class TestDjangoFormatter < FormatterTest
@@ -389,6 +418,11 @@ class TestDjangoFormatter < FormatterTest
   def test_deducts_language_and_region
     language = "en-GB"
     assert_equal language, @formatter.determine_language_given_path("#{language}.po")
+  end
+
+  def test_deducts_language_from_path
+    language = %w(en-GB de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
   end
 end
 
@@ -420,10 +454,10 @@ class TestFlashFormatter < FormatterTest
 
   def test_deducts_language_from_resource_folder
     language = %w(en de fr).sample
-    assert_equal language, @formatter.determine_language_given_path("locale/#{language}")
+    assert_equal language, @formatter.determine_language_given_path("locale/#{language}/#{@formatter.default_file_name}")
   end
 
   def test_deducts_language_and_region_from_resource_folder
-    assert_equal 'de-AT', @formatter.determine_language_given_path("locale/de-AT")
+    assert_equal 'de-AT', @formatter.determine_language_given_path("locale/de-AT/#{@formatter.default_file_name}")
   end
 end


### PR DESCRIPTION
This fixes the issue raised in #250.

It turned out to be a bigger issue actually effecting all but the Apple and Android formatter. The problem was, that `output_path_for_language` is implemented in `Abstract` but the corresponding `determine_language_given_path` left the task of recognizing the language from a folder name up to the formatter implementations. Some took care of it, some didn't. Most didn't.

While I was on it, I also put the recognition of a filename like `[language code].[extension]` there. This _could_ change the behaviour of `Runner.generate_all_localization_files` because it calls `formatter.determine_language_given_path` but did not call the now deleted `Runner.determine_language_given_path` - I don't see how though.