### PR TITLE
Revert "Only recognize two letter language codes (with optional two letter region codes) as languages when deducting the language from filenames."

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -3,8 +3,6 @@ require 'fileutils'
 module Twine
   module Formatters
     class Abstract
-      LANGUAGE_CODE_WITH_OPTIONAL_REGION_CODE = "[a-z]{2}(?:-[A-Za-z]{2})?"
-
       attr_accessor :twine_file
       attr_accessor :options
 
@@ -78,11 +76,7 @@ module Twine
       end
 
       def determine_language_given_path(path)
-        only_language_and_region = /^#{LANGUAGE_CODE_WITH_OPTIONAL_REGION_CODE}$/i
-        basename = File.basename(path, File.extname(path))
-        return basename if basename =~ only_language_and_region
-        
-        path.split(File::SEPARATOR).reverse.find { |segment| segment =~ only_language_and_region }
+        raise NotImplementedError.new("You must implement determine_language_given_path in your formatter class.")
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -37,7 +37,7 @@ module Twine
           end
         end
 
-        return super
+        return
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/apple.rb
+++ b/lib/twine/formatters/apple.rb
@@ -30,7 +30,7 @@ module Twine
           end
         end
 
-        return super
+        return
       end
 
       def output_path_for_language(lang)

--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -13,6 +13,16 @@ module Twine
         'strings.po'
       end
 
+      def determine_language_given_path(path)
+        path_arr = path.split(File::SEPARATOR)
+        path_arr.each do |segment|
+          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
+          return match[1] if match
+        end
+        
+        return
+      end
+
       def read(io, lang)
         comment_regex = /#\. *"?(.*)"?$/
         key_regex = /msgid *"(.*)"$/

--- a/lib/twine/formatters/flash.rb
+++ b/lib/twine/formatters/flash.rb
@@ -15,6 +15,11 @@ module Twine
         'resources.properties'
       end
 
+      def determine_language_given_path(path)
+        # match two-letter language code, optionally followed by a two letter region code
+        path.split(File::SEPARATOR).reverse.find { |segment| segment =~ /^([a-z]{2}(-[a-z]{2})?)$/i }
+      end
+
       def set_translation_for_key(key, lang, value)
         value = convert_placeholders_from_flash_to_twine(value)
         super(key, lang, value)

--- a/lib/twine/formatters/gettext.rb
+++ b/lib/twine/formatters/gettext.rb
@@ -15,6 +15,16 @@ module Twine
         'strings.po'
       end
 
+      def determine_language_given_path(path)
+        path_arr = path.split(File::SEPARATOR)
+        path_arr.each do |segment|
+          match = /([a-z]{2}(-[A-Za-z]{2})?)\.po$/.match(segment)
+          return match[1] if match
+        end
+
+        return
+      end
+
       def read(io, lang)
         comment_regex = /#.? *"(.*)"$/
         key_regex = /msgctxt *"(.*)"$/

--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -14,17 +14,22 @@ module Twine
       end
 
       def determine_language_given_path(path)
-        match = /^.+-([^-]{2})\.json$/.match File.basename(path)
-        return match[1] if match
+        path_arr = path.split(File::SEPARATOR)
+        path_arr.each do |segment|
+          match = /^((.+)-)?([^-]+)\.json$/.match(segment)
+          if match
+            return match[3]
+          end
+        end
 
-        return super
+        return
       end
 
       def read(io, lang)
         begin
           require "json"
         rescue LoadError
-          raise Twine::Error.new "You must run `gem install json` in order to read or write jquery-localize files."
+          raise Twine::Error.new "You must run 'gem install json' in order to read or write jquery-localize files."
         end
 
         json = JSON.load(io)

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -294,6 +294,11 @@ module Twine
       end
     end
 
+    def determine_language_given_path(path)
+      code = File.basename(path, File.extname(path))
+      return code if @twine_file.language_codes.include? code
+    end
+
     def formatter_for_format(format)
       find_formatter { |f| f.format_name == format }
     end
@@ -337,7 +342,7 @@ module Twine
         raise Twine::Error.new "Unable to determine format of #{path}"
       end      
 
-      lang = lang || formatter.determine_language_given_path(path)
+      lang = lang || determine_language_given_path(path) || formatter.determine_language_given_path(path)
       unless lang
         raise Twine::Error.new "Unable to determine language for #{path}"
       end

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -195,13 +195,8 @@ class TestAndroidFormatter < FormatterTest
     assert_equal identifier, @formatter.format_value(identifier)
   end
 
-  def test_deducts_language_from_filename
-    language = KNOWN_LANGUAGES.sample
-    assert_equal language, @formatter.determine_language_given_path("#{language}.xml")
-  end
-
   def test_deducts_language_from_resource_folder
-    language = KNOWN_LANGUAGES.sample
+    language = %w(en de fr).sample
     assert_equal language, @formatter.determine_language_given_path("res/values-#{language}")
   end
 
@@ -231,11 +226,6 @@ class TestAppleFormatter < FormatterTest
     @formatter.read content_io('formatter_apple.strings'), 'en'
 
     assert_file_contents_read_correctly
-  end
-
-  def test_deducts_language_from_filename
-    language = KNOWN_LANGUAGES.sample
-    assert_equal language, @formatter.determine_language_given_path("#{language}.strings")
   end
 
   def test_deducts_language_from_resource_folder
@@ -342,21 +332,6 @@ class TestJQueryFormatter < FormatterTest
   def test_format_value_with_newline
     assert_equal "value\nwith\nline\nbreaks", @formatter.format_value("value\nwith\nline\nbreaks")
   end
-
-  def test_deducts_language_from_filename
-    language = KNOWN_LANGUAGES.sample
-    assert_equal language, @formatter.determine_language_given_path("#{language}.json")
-  end
-
-  def test_deducts_language_from_extended_filename
-    language = KNOWN_LANGUAGES.sample
-    assert_equal language, @formatter.determine_language_given_path("something-#{language}.json")
-  end
-
-  def test_deducts_language_from_path
-    language = %w(en-GB de fr).sample
-    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
-  end
 end
 
 class TestGettextFormatter < FormatterTest
@@ -386,11 +361,6 @@ class TestGettextFormatter < FormatterTest
     language = "en-GB"
     assert_equal language, @formatter.determine_language_given_path("#{language}.po")
   end
-
-  def test_deducts_language_from_path
-    language = %w(en-GB de fr).sample
-    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
-  end
 end
 
 class TestTizenFormatter < FormatterTest
@@ -411,6 +381,7 @@ class TestTizenFormatter < FormatterTest
     formatter.twine_file = @twine_file
     assert_equal content('formatter_tizen.xml'), formatter.format_file('en')
   end
+
 end
 
 class TestDjangoFormatter < FormatterTest
@@ -433,11 +404,6 @@ class TestDjangoFormatter < FormatterTest
   def test_deducts_language_and_region
     language = "en-GB"
     assert_equal language, @formatter.determine_language_given_path("#{language}.po")
-  end
-
-  def test_deducts_language_from_path
-    language = %w(en-GB de fr).sample
-    assert_equal language, @formatter.determine_language_given_path("/output/#{language}/#{@formatter.default_file_name}")
   end
 end
 
@@ -469,10 +435,10 @@ class TestFlashFormatter < FormatterTest
 
   def test_deducts_language_from_resource_folder
     language = %w(en de fr).sample
-    assert_equal language, @formatter.determine_language_given_path("locale/#{language}/#{@formatter.default_file_name}")
+    assert_equal language, @formatter.determine_language_given_path("locale/#{language}")
   end
 
   def test_deducts_language_and_region_from_resource_folder
-    assert_equal 'de-AT', @formatter.determine_language_given_path("locale/de-AT/#{@formatter.default_file_name}")
+    assert_equal 'de-AT', @formatter.determine_language_given_path("locale/de-AT")
   end
 end


### PR DESCRIPTION
This reverts commit 094ba47ac8e60005271f6daf6706144058c87e03.

This commit broke Twine for iOS when using Chinese languages. Can we revert and re-introduce the fix to accommodate `zh-Hant` and `zh-Hans`?