### PR TITLE
Deduct language from filename

### DIFF
--- a/lib/twine/formatters/abstract.rb
+++ b/lib/twine/formatters/abstract.rb
@@ -81,6 +81,7 @@ module Twine
         only_language_and_region = /^#{LANGUAGE_CODE_WITH_OPTIONAL_REGION_CODE}$/i
         basename = File.basename(path, File.extname(path))
         return basename if basename =~ only_language_and_region
+        return basename if @twine_file.language_codes.include? basename
         
         path.split(File::SEPARATOR).reverse.find { |segment| segment =~ only_language_and_region }
       end

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -87,7 +87,7 @@ module Twine
       end
       
       unless formatter
-        raise Twine::Error.new "Could not determine format given the contents of #{@options[:output_path]}"
+        raise Twine::Error.new "Could not determine format given the contents of #{@options[:output_path]}. Try using `--format`."
       end
 
       file_name = @options[:file_name] || formatter.default_file_name
@@ -303,7 +303,7 @@ module Twine
       if formatters.empty?
         return nil
       elsif formatters.size > 1
-        raise Twine::Error.new("Unable to determine format. Candidates are: #{formatters.map(&:format_name).join(', ')}. Please specify the format you want using '--format'")
+        raise Twine::Error.new("Unable to determine format. Candidates are: #{formatters.map(&:format_name).join(', ')}. Please specify the format you want using `--format`")
       end
       formatter = formatters.first
       formatter.twine_file = @twine_file
@@ -334,12 +334,12 @@ module Twine
       end
       
       unless formatter
-        raise Twine::Error.new "Unable to determine format of #{path}"
+        raise Twine::Error.new "Unable to determine format of #{path}. Try using `--format`."
       end      
 
       lang = lang || formatter.determine_language_given_path(path)
       unless lang
-        raise Twine::Error.new "Unable to determine language for #{path}"
+        raise Twine::Error.new "Unable to determine language for #{path}. Try using `--lang`."
       end
 
       @twine_file.language_codes << lang unless @twine_file.language_codes.include? lang

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -200,6 +200,17 @@ class TestAndroidFormatter < FormatterTest
     assert_equal language, @formatter.determine_language_given_path("#{language}.xml")
   end
 
+  def test_recognize_every_twine_language_from_filename
+    twine_file = build_twine_file "not-a-lang-code" do
+      add_section "Section" do
+        add_definition key: "value"
+      end
+    end
+
+    @formatter.twine_file = twine_file
+    assert_equal "not-a-lang-code", @formatter.determine_language_given_path("not-a-lang-code.xml")
+  end
+
   def test_deducts_language_from_resource_folder
     language = KNOWN_LANGUAGES.sample
     assert_equal language, @formatter.determine_language_given_path("res/values-#{language}")
@@ -236,6 +247,17 @@ class TestAppleFormatter < FormatterTest
   def test_deducts_language_from_filename
     language = KNOWN_LANGUAGES.sample
     assert_equal language, @formatter.determine_language_given_path("#{language}.strings")
+  end
+
+  def test_recognize_every_twine_language_from_filename
+    twine_file = build_twine_file "not-a-lang-code" do
+      add_section "Section" do
+        add_definition key: "value"
+      end
+    end
+
+    @formatter.twine_file = twine_file
+    assert_equal "not-a-lang-code", @formatter.determine_language_given_path("not-a-lang-code.strings")
   end
 
   def test_deducts_language_from_resource_folder


### PR DESCRIPTION
Fixing #250 introduced a regression in 094ba47: the language was no longer deducted from the given filename - where "language" means "anything on the left side of the equal sign in the Twine file".

This PR makes #256 obsolete.

I've also added hints to some error messages on how to solve the reported error.