### PR TITLE
Fixed first run description

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This command validates that the Twine data file can be parsed, contains no dupli
 The easiest way to create your first Twine data file is to run the [`consume-all-localization-files`](#consume-all-localization-files) command. The one caveat is to first create a blank file to use as your starting point. Then, just point the `consume-all-localization-files` command at a directory in your project containing all of your localization files.
 
 	$ touch twine.txt
-	$ twine consume-all-localization-files twine.txt Resources/Locales --developer-language en --consume-all --consume-comments
+	$ twine consume-all-localization-files twine.txt Resources/Locales --developer-language en --consume-all --consume-comments --format apple/android/gettext/jquery/django/tizen/flash
 
 ## Twine and Your Build Process
 


### PR DESCRIPTION
Doesn't run without the --format part - added all possible format possibilities.