### PR TITLE
Fix Warnings When Running Rake Test

### DIFF
--- a/lib/twine/formatters/django.rb
+++ b/lib/twine/formatters/django.rb
@@ -18,7 +18,6 @@ module Twine
         key_regex = /msgid *"(.*)"$/
         value_regex = /msgstr *"(.*)"$/m
 
-        last_comment = nil
         while line = io.gets          
           comment_match = comment_regex.match(line)
           if comment_match

--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -41,7 +41,7 @@ module Twine
 
       def format_sections(twine_file, lang)
         sections = twine_file.sections.map { |section| format_section(section, lang) }
-        sections.delete_if &:empty?
+        sections.delete_if(&:empty?)
         sections.join(",\n\n")
       end
 

--- a/lib/twine/plugin.rb
+++ b/lib/twine/plugin.rb
@@ -57,7 +57,7 @@ module Twine
     end
 
     def join_path *paths
-      File.expand_path File.join *paths
+      File.expand_path File.join(*paths)
     end
   end
 end

--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -299,7 +299,7 @@ module Twine
     end
 
     def find_formatter(&block)
-      formatters = Formatters.formatters.select &block
+      formatters = Formatters.formatters.select(&block)
       if formatters.empty?
         return nil
       elsif formatters.size > 1


### PR DESCRIPTION
Fixes a few of these:

```
DTWC02LV1V5FD58:twine dlevy$ rake test
/Users/dlevy/dev/twine/lib/twine/plugin.rb:60: warning: `*' interpreted as argument prefix
/Users/dlevy/dev/twine/lib/twine/twine_file.rb:17: warning: method redefined; discarding old comment
/Users/dlevy/dev/twine/lib/twine/placeholders.rb:73: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/dlevy/dev/twine/lib/twine/formatters/android.rb:146: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/dlevy/dev/twine/lib/twine/formatters/android.rb:157: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/dlevy/dev/twine/lib/twine/formatters/django.rb:21: warning: assigned but unused variable - last_comment
/Users/dlevy/dev/twine/lib/twine/formatters/jquery.rb:44: warning: `&' interpreted as argument prefix
/Users/dlevy/dev/twine/lib/twine/runner.rb:302: warning: `&' interpreted as argument prefix
/Users/dlevy/dev/twine/test/test_cli.rb:23: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Run options: --seed 64197

# Running:

...............................................................................................................S.....................................................................................................

Finished in 0.769036s, 276.9701 runs/s, 555.2406 assertions/s.

213 runs, 427 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
```