### PR TITLE
Replace -rubygems with -rrubygems

### DIFF
--- a/twine
+++ b/twine
@@ -1,3 +1,3 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
-ruby -rubygems -I $BASEDIR/lib $BASEDIR/bin/twine "$@"
+ruby -rrubygems -I $BASEDIR/lib $BASEDIR/bin/twine "$@"


### PR DESCRIPTION
The old one was a thing before Ruby 2.0.