### PR TITLE
Android output path for default language

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -41,7 +41,11 @@ module Twine
       end
 
       def output_path_for_language(lang)
-        "values-#{lang}".gsub(/-(\p{Lu})/, '-r\1')
+        if lang == @twine_file.language_codes[0]
+          "values"
+        else
+          "values-#{lang}".gsub(/-(\p{Lu})/, '-r\1')
+        end
       end
 
       def set_translation_for_key(key, lang, value)

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -231,6 +231,13 @@ class TestAndroidFormatter < FormatterTest
   def test_output_path_with_region
     assert_equal 'values-en-rGB', @formatter.output_path_for_language('en-GB')
   end
+
+  def test_output_path_respects_default_lang
+    @formatter.twine_file.language_codes.concat KNOWN_LANGUAGES
+    non_default_language = KNOWN_LANGUAGES[1..-1].sample
+    assert_equal 'values', @formatter.output_path_for_language(KNOWN_LANGUAGES[0])
+    assert_equal "values-#{non_default_language}", @formatter.output_path_for_language(non_default_language)
+  end
 end
 
 class TestAppleFormatter < FormatterTest


### PR DESCRIPTION
This addresses https://github.com/scelis/twine/issues/225 and changes the android formatter to behave like suggested in https://github.com/scelis/twine/issues/225#issuecomment-393457223.

Now the android formatter takes the `--developer-language` flag into account when it is used in conjunction with `generate_all_localization_files`.

The brings the behavior in line with the documentation of `--developer-language`:

> When generating files this language will be used as *default language* and its translations will be used if a definition is not localized for the output language.
>
> -- <cite>[cli.rb](https://github.com/scelis/twine/blob/master/lib/twine/cli.rb#L33)</cite>


On android the *default* language lives in the folder `res/values/` (no language specifier):

> Android loads the default strings from res/values/strings.xml
>
> -- <cite>[developer.android.com](https://developer.android.com/guide/topics/resources/localization#defaults-r-important)</cite>

It now also works analogous to `determine_language_given_path` where the default language is already considered.
