### PR TITLE
Support more Android styling tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next version
+
+- Improvement: Support more Android styling tags (#278)
+
 # 1.0.5 (2019-02-24)
 
 - Bugfix: Incorrect language detection when reading localization files (#251)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Twine currently supports the following output formats:
 * [Android String Resources][androidstrings] (format: android)
     * HTML tags will be escaped by replacing `<` with `&lt`
     * Tags inside `<![CDATA[` won't be escaped.
-    * Supports [basic styling][androidstyling] with `<b>`, `<i>`, `<u>` and `<a>` links.
+    * Supports [basic styling][androidstyling] according to [Android documentation](https://developer.android.com/guide/topics/resources/string-resource.html#StylingWithHTML).  All of the documented tags are supported, in addition to `<a>` links.
 	    * These tags will *not* be escaped if the string doesn't contain placeholders. You can reference them directly in your layouts or by using [`getText()`](https://developer.android.com/reference/android/content/res/Resources.html#getText(int)) to read them programatically.
 	    * These tags *will* be escaped if the string contains placeholders. You can use [`getString()`](https://developer.android.com/reference/android/content/res/Resources.html#getString(int,%20java.lang.Object...)) combined with [`fromHtml`](https://developer.android.com/reference/android/text/Html.html#fromHtml(java.lang.String)) as shown in the [documentation][androidstyling] to display them.
 	* See [\#212](https://github.com/scelis/twine/issues/212) for details.

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -113,22 +113,26 @@ module Twine
 
       # http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling
       def escape_value(value)
-        inside_cdata = /<\!\[CDATA\[((?!\]\]>).)*$/       # opening CDATA tag ('<![CDATA[') not followed by a closing tag (']]>')
-        inside_opening_anchor_tag = /<a\s?((?!>).)*$/     # anchor tag start ('<a ') not followed by a '>'
+        inside_cdata = /<\!\[CDATA\[((?!\]\]>).)*$/              # opening CDATA tag ('<![CDATA[') not followed by a closing tag (']]>')
+        inside_opening_tag = /<(a|font|span|p)\s?((?!>).)*$/     # tag start ('<a ', '<font ', '<span ' or '<p ') not followed by a '>'
 
         # escape double and single quotes and & signs
-        value = gsub_unless(value, '"', '\\"') { |substring| substring =~ inside_cdata || substring =~ inside_opening_anchor_tag }
+        value = gsub_unless(value, '"', '\\"') { |substring| substring =~ inside_cdata || substring =~ inside_opening_tag }
         value = gsub_unless(value, "'", "\\'") { |substring| substring =~ inside_cdata }
-        value = gsub_unless(value, /&/, '&amp;') { |substring| substring =~ inside_cdata || substring =~ inside_opening_anchor_tag }
+        value = gsub_unless(value, /&/, '&amp;') { |substring| substring =~ inside_cdata || substring =~ inside_opening_tag }
 
         # if `value` contains a placeholder, escape all angle brackets
         # if not, escape opening angle brackes unless it's a supported styling tag
         # https://github.com/scelis/twine/issues/212
         # https://stackoverflow.com/questions/3235131/#18199543
         if number_of_twine_placeholders(value) > 0
-          angle_bracket = /<(?!(\/?(\!\[CDATA)))/           # matches all `<` but <![CDATA
-        else  
-          angle_bracket = /<(?!(\/?(b|u|i|a|\!\[CDATA)))/   # matches all `<` but <b>, <u>, <i>, <a> and <![CDATA
+          # matches all `<` but <![CDATA
+          angle_bracket = /<(?!(\/?(\!\[CDATA)))/
+        else
+          # matches all '<' but <b>, <em>, <i>, <cite>, <dfn>, <big>, <small>, <font>, <tt>, <s>,
+          # <strike>, <del>, <u>, <super>, <sub>, <ul>, <li>, <br>, <div>, <span>, <p>, <a>
+          # and <![CDATA
+          angle_bracket = /<(?!(\/?(b|em|i|cite|dfn|big|small|font|tt|s|strike|del|u|super|sub|ul|li|br|div|span|p|a|\!\[CDATA)))/
         end
         value = gsub_unless(value, angle_bracket, '&lt;') { |substring| substring =~ inside_cdata }
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -47,26 +47,87 @@ class TestAndroidFormatter < FormatterTest
       'a "good" way'              => 'a \"good\" way',
 
       '<b>bold</b>'               => '<b>bold</b>',
+      '<em>bold</em>'             => '<em>bold</em>',
+
       '<i>italic</i>'             => '<i>italic</i>',
+      '<cite>italic</cite>'       => '<cite>italic</cite>',
+      '<dfn>italic</dfn>'         => '<dfn>italic</dfn>',
+
+      '<big>larger</big>'         => '<big>larger</big>',
+      '<small>smaller</small>'    => '<small>smaller</small>',
+
+      '<font color="#45C1D0">F</font>' => '<font color="#45C1D0">F</font>',
+
+      '<tt>monospaced</tt>'       => '<tt>monospaced</tt>',
+
+      '<s>strike</s>'             => '<s>strike</s>',
+      '<strike>strike</strike>'   => '<strike>strike</strike>',
+      '<del>strike</del>'         => '<del>strike</del>',
+
       '<u>underline</u>'          => '<u>underline</u>',
 
+      '<super>superscript</super>'=> '<super>superscript</super>',
+
+      '<sub>subscript</sub>'      => '<sub>subscript</sub>',
+
+      '<ul>bullet point</ul>'     => '<ul>bullet point</ul>',
+      '<li>bullet point</li>'     => '<li>bullet point</li>',
+
+      '<br>line break'            => '<br>line break',
+
+      '<div>division</div>'       => '<div>division</div>',
+
+      '<span style="color:#45C1D0">inline</span>' => '<span style="color:#45C1D0">inline</span>',
+
+      '<p>para</p>'               => '<p>para</p>',
+      '<p dir="ltr">para</p>'     => '<p dir="ltr">para</p>',
+
       '<b>%@</b>'                 => '&lt;b>%s&lt;/b>',
+      '<em>%@</em>'               => '&lt;em>%s&lt;/em>',
+
       '<i>%@</i>'                 => '&lt;i>%s&lt;/i>',
+      '<cite>%@</cite>'           => '&lt;cite>%s&lt;/cite>',
+      '<dfn>%@</dfn>'             => '&lt;dfn>%s&lt;/dfn>',
+
+      '<big>%@</big>'             => '&lt;big>%s&lt;/big>',
+      '<small>%@</small>'         => '&lt;small>%s&lt;/small>',
+
+      '<font color="#45C1D0>%@</font>' => '&lt;font color="#45C1D0>%s&lt;/font>',
+
+      '<tt>%@</tt>'               => '&lt;tt>%s&lt;/tt>',
+
+      '<s>%@</s>'                 => '&lt;s>%s&lt;/s>',
+      '<strike>%@</strike>'       => '&lt;strike>%s&lt;/strike>',
+      '<del>%@</del>'             => '&lt;del>%s&lt;/del>',
+
       '<u>%@</u>'                 => '&lt;u>%s&lt;/u>',
 
-      '<span>inline</span>'       => '&lt;span>inline&lt;/span>',
-      '<p>paragraph</p>'          => '&lt;p>paragraph&lt;/p>',
+      '<super>%@</super>'         => '&lt;super>%s&lt;/super>',
+
+      '<sub>%@</sub>'             => '&lt;sub>%s&lt;/sub>',
+
+      '<ul>%@</ul>'               => '&lt;ul>%s&lt;/ul>',
+      '<li>%@</li>'               => '&lt;li>%s&lt;/li>',
+
+      '<br>%@'                    => '&lt;br>%s',
+
+      '<div>%@</div>'             => '&lt;div>%s&lt;/div>',
+
+      '<span style="color:#45C1D0">%@</span>' => '&lt;span style="color:#45C1D0">%s&lt;/span>',
+
+      '<p>%@</p>'                 => '&lt;p>%s&lt;/p>',
+      '<p dir="ltr">%@</p>'       => '&lt;p dir="ltr">%s&lt;/p>',
 
       '<a href="target">link</a>'     => '<a href="target">link</a>',
       '<a href="target">"link"</a>'   => '<a href="target">\"link\"</a>',
       '<a href="target"></a>"out"'    => '<a href="target"></a>\"out\"',
       '<a href="http://url.com?param=1&param2=3&param3=%20">link</a>'   =>   '<a href="http://url.com?param=1&param2=3&param3=%20">link</a>',
 
-      '<p>escaped</p><![CDATA[]]>'                => '&lt;p>escaped&lt;/p><![CDATA[]]>',
-      '<![CDATA[]]><p>escaped</p>'                => '<![CDATA[]]>&lt;p>escaped&lt;/p>',
-      '<![CDATA[<p>unescaped</p>]]>'              => '<![CDATA[<p>unescaped</p>]]>',
-      '<![CDATA[<p>unescaped with %@</p>]]>'      => '<![CDATA[<p>unescaped with %s</p>]]>',
-      '<![CDATA[]]><![CDATA[<p>unescaped</p>]]>'  => '<![CDATA[]]><![CDATA[<p>unescaped</p>]]>',
+      '<q>escaped</q><![CDATA[]]>'                => '&lt;q>escaped&lt;/q><![CDATA[]]>',
+      '<![CDATA[]]><q>escaped</q>'                => '<![CDATA[]]>&lt;q>escaped&lt;/q>',
+      '<![CDATA[<q>unescaped</q>]]>'              => '<![CDATA[<q>unescaped</q>]]>',
+      '<![CDATA[<q>unescaped with %@</q>]]>'      => '<![CDATA[<q>unescaped with %s</q>]]>',
+      '<![CDATA[]]><![CDATA[<q>unescaped</q>]]>'  => '<![CDATA[]]><![CDATA[<q>unescaped</q>]]>',
 
       '<![CDATA[&]]>'  => '<![CDATA[&]]>',
       '<![CDATA[\']]>' => '<![CDATA[\']]>',


### PR DESCRIPTION
Adds support for all Android styling tags currently listed in the [official documentation](https://developer.android.com/guide/topics/resources/string-resource.html#StylingWithHTML). #278 

Note that those tags are not new, most of them are supported for almost a decade now (Android 2.1). They were just listed recently in the docs, which are still incomplete. Even the `<a>` tag is not listed yet, although Twine supports it (as it should).