### PR TITLE
Add --escape-all-tags flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Feature: Add --escape-all-tags option to force escping of Android styling tags (#281)
+- Feature: Add --escape-all-tags option to force escaping of Android styling tags (#281)
 
 # 1.0.6 (2019-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Feature: Add --escape-all-tags option to force escping of Android styling tags (#281)
+
 # 1.0.6 (2019-05-28)
 
 - Improvement: Support more Android styling tags (#278)

--- a/lib/twine/cli.rb
+++ b/lib/twine/cli.rb
@@ -45,6 +45,14 @@ module Twine
           files are UTF-16 without BOM, you need to specify if it's UTF-16LE or UTF16-BE.
         DESC
       },
+      escape_all_tags: {
+        switch: ['--[no-]escape-all-tags'],
+        description: <<-DESC,
+          Always escape all HTML tags. By default the Android formatter will ONLY escape styling tags, if a 
+          string also contains placeholders. This flag enforces that styling tags are escaped regardless of
+          placeholders.
+        DESC
+      },
       file_name: {
         switch: ['-n', '--file-name FILE_NAME'],
         description: 'This flag may be used to overwrite the default file name of the format.'
@@ -111,6 +119,7 @@ module Twine
         optional_options: [
           :developer_language,
           :encoding,
+          :escape_all_tags,
           :format,
           :include,
           :languages,
@@ -133,6 +142,7 @@ module Twine
           :create_folders,
           :developer_language,
           :encoding,
+          :escape_all_tags,
           :file_name,
           :format,
           :include,
@@ -152,6 +162,7 @@ module Twine
         optional_options: [
           :developer_language,
           :encoding,
+          :escape_all_tags,
           :include,
           :quiet,
           :tags,

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -125,7 +125,7 @@ module Twine
         # if not, escape opening angle brackes unless it's a supported styling tag
         # https://github.com/scelis/twine/issues/212
         # https://stackoverflow.com/questions/3235131/#18199543
-        if number_of_twine_placeholders(value) > 0
+        if number_of_twine_placeholders(value) > 0 or @options[:escape_all_tags]
           # matches all `<` but <![CDATA
           angle_bracket = /<(?!(\/?(\!\[CDATA)))/
         else

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -48,6 +48,13 @@ class CLITest < TwineTest
     assert_equal 'UTF16', @options[:encoding]
   end
 
+  def assert_option_escape_all_tags
+    parse_with "--escape-all-tags"
+    assert @options[:escape_all_tags]
+    parse_with "--no-escape-all-tags"
+    refute @options[:escape_all_tags]
+  end
+
   def assert_option_format
     random_format = Twine::Formatters.formatters.sample.format_name.downcase
     parse_with "--format #{random_format}"
@@ -177,6 +184,7 @@ class TestGenerateLocalizationFileCLI < CLITest
     assert_help
     assert_option_developer_language
     assert_option_encoding
+    assert_option_escape_all_tags
     assert_option_format
     assert_option_include
     assert_option_single_language
@@ -217,6 +225,7 @@ class TestGenerateAllLocalizationFilesCLI < CLITest
     assert_help
     assert_option_developer_language
     assert_option_encoding
+    assert_option_escape_all_tags
     assert_option_format
     assert_option_include
     assert_option_quiet
@@ -268,6 +277,7 @@ class TestGenerateLocalizationArchiveCLI < CLITest
     assert_help
     assert_option_developer_language
     assert_option_encoding
+    assert_option_escape_all_tags
     assert_option_include
     assert_option_quiet
     assert_option_tags

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -138,6 +138,11 @@ class TestAndroidFormatter < FormatterTest
       '<xliff:g id="42">untouched</xliff:g>' => '<xliff:g id="42">untouched</xliff:g>',
       '<xliff:g id="1">first</xliff:g> inbetween <xliff:g id="2">second</xliff:g>' => '<xliff:g id="1">first</xliff:g> inbetween <xliff:g id="2">second</xliff:g>'
     }
+    @escape_all_test_values = {
+      '<b>bold</b>'               => '&lt;b>bold&lt;/b>',
+      '<i>italic</i>'             => '&lt;i>italic&lt;/i>',
+      '<u>underline</u>'          => '&lt;u>underline&lt;/u>'      
+    }
   end
 
   def test_read_format
@@ -217,6 +222,11 @@ class TestAndroidFormatter < FormatterTest
       @formatter.set_translation_for_key 'key1', 'en', input
       assert_equal expected, @empty_twine_file.definitions_by_key['key1'].translations['en']
     end
+
+    @escape_all_test_values.each do |expected, input|
+      @formatter.set_translation_for_key 'key1', 'en', input
+      assert_equal expected, @empty_twine_file.definitions_by_key['key1'].translations['en']
+    end
   end
 
   def test_format_file
@@ -243,6 +253,11 @@ class TestAndroidFormatter < FormatterTest
 
   def test_format_value_escaping
     @escape_test_values.each do |input, expected|
+      assert_equal expected, @formatter.format_value(input)
+    end
+
+    @formatter.options.merge!({ escape_all_tags: true })
+    @escape_all_test_values.each do |input, expected|
       assert_equal expected, @formatter.format_value(input)
     end
   end


### PR DESCRIPTION
To force the Android formatter to always escape styling tags.

Closes #281