### PR TITLE
Update rubyzip to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,5 @@
 version: 2.0
 jobs:
-    "ruby-2.2":
-        docker:
-            - image: circleci/ruby:2.2
-        steps:
-            - checkout
-            - run: bundle install
-            - run: bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
-    "ruby-2.3":
-        docker:
-            - image: circleci/ruby:2.3
-        steps:
-            - checkout
-            - run: bundle install
-            - run: bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
     "ruby-2.4":
         docker:
             - image: circleci/ruby:2.4
@@ -28,11 +14,25 @@ jobs:
             - checkout
             - run: bundle install
             - run: bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
+    "ruby-2.6":
+        docker:
+            - image: circleci/ruby:2.6
+        steps:
+            - checkout
+            - run: bundle install
+            - run: bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
+    "ruby-2.7":
+        docker:
+            - image: circleci/ruby:2.7
+        steps:
+            - checkout
+            - run: bundle install
+            - run: bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports"
 workflows:
     version: 2
     build:
         jobs:
-            - "ruby-2.2"
-            - "ruby-2.3"
             - "ruby-2.4"
             - "ruby-2.5"
+            - "ruby-2.6"
+            - "ruby-2.7"

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files       += Dir.glob("test/**/*")
   s.test_files   = Dir.glob("test/test_*")
 
-  s.required_ruby_version = ">= 2.0"
+  s.required_ruby_version = ">= 2.4"
   s.add_runtime_dependency('rubyzip', "~> 2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
   s.add_development_dependency('rake', "~> 13.0")

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files   = Dir.glob("test/test_*")
 
   s.required_ruby_version = ">= 2.0"
-  s.add_runtime_dependency('rubyzip', "~> 1.1")
+  s.add_runtime_dependency('rubyzip', "~> 2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
   s.add_development_dependency('rake', "~> 13.0")
   s.add_development_dependency('minitest', "~> 5.5")


### PR DESCRIPTION
[rubyzip](https://github.com/rubyzip/rubyzip/blob/master/Changelog.md) has gone from v1 to v2 and in doing so has dropped support for versions of Ruby before 2.4. It seems as good a time as any, so let's do the same.

Replace our 2.2 and 2.3 unit tests with 2.6 and 2.7.