### PR TITLE
Slurp Android mulitline comments as single-line

### DIFF
--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -65,6 +65,7 @@ module Twine
         document.root.children.each do |child|
           if child.is_a? REXML::Comment
             content = child.string.strip
+            content.gsub!(/[\s]+/, ' ')
             comment = content if content.length > 0 and not content.start_with?("SECTION:")
           elsif child.is_a? REXML::Element
             next unless child.name == 'string'

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -167,6 +167,24 @@ class TestAndroidFormatter < FormatterTest
     assert_equal 'This is\n a string', @empty_twine_file.definitions_by_key["foo"].translations['en']
   end
 
+  def test_read_multiline_comment
+    content = <<-EOCONTENT
+      <?xml version="1.0" encoding="utf-8"?>
+      <resources>
+        <!-- multiline
+        comment -->
+        <string name="foo">This is
+     a string</string>
+      </resources>
+    EOCONTENT
+
+    io = StringIO.new(content)
+
+    @formatter.read io, 'en'
+
+    assert_equal 'multiline comment', @empty_twine_file.definitions_by_key["foo"].comment
+  end
+
   def test_read_html_tags
     content = <<-EOCONTENT
       <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Multi-line comments were causing the twine file format to break, and subsequent reads of the twine file were failing in different ways.