### PR TITLE
chore: fix typo in formatters.md

### DIFF
--- a/documentation/formatters.md
+++ b/documentation/formatters.md
@@ -61,7 +61,7 @@ Formatters inherit from [`Abstract`](/lib/twine/formatters/abstract.rb) and need
 
 The `Abstract` formatter also specifies two utility methods to be used when read a localization file, `set_translation_for_key` and `set_comment_for_key`, however the actual parsing is too formatter specific and must be implemented in the `read` method of a formatter.
 
-Which methods to overwrite to produce the desired output depends pretty much on the format. Again, looking at the [bundeled formatters](/lib/twine/formatters) will provide some insight.
+Which methods to overwrite to produce the desired output depends pretty much on the format. Again, looking at the [bundled formatters](/lib/twine/formatters) will provide some insight.
 
 Finally, to make a formatter available, it needs to be added to the list of formatters
 


### PR DESCRIPTION
s/bundeled/bundled in formatters.md