### PR TITLE
Created Flutter formatter to handle ".arb" files

### DIFF
--- a/lib/twine.rb
+++ b/lib/twine.rb
@@ -33,6 +33,7 @@ module Twine
   require 'twine/formatters/apple'
   require 'twine/formatters/django'
   require 'twine/formatters/flash'
+  require 'twine/formatters/flutter'
   require 'twine/formatters/gettext'
   require 'twine/formatters/jquery'
   require 'twine/formatters/tizen'

--- a/lib/twine/formatters/flutter.rb
+++ b/lib/twine/formatters/flutter.rb
@@ -1,0 +1,80 @@
+module Twine
+  module Formatters
+    class Flutter < Abstract
+      def format_name
+        'flutter'
+      end
+
+      def extension
+        '.arb'
+      end
+
+      def default_file_name
+        'app.arb'
+      end
+
+      def determine_language_given_path(path)
+        match = /^.+_([^-]{2})\.arb$/.match File.basename(path)
+        return match[1] if match
+
+        return super
+      end
+
+      def read(io, lang)
+        begin
+          require "json"
+        rescue LoadError
+          raise Twine::Error.new "You must run `gem install json` in order to read or write flutter files."
+        end
+
+        json = JSON.load(io)
+        json.each do |key, value|
+          if key == "@@locale"
+            # Ignore because it represents the file lang
+          elsif key[0,1] == "@"
+            description_value = "{\n        \"description\":\"#{value}\"\n    }"
+            set_comment_for_key(key.slice!(0), lang, value)
+          else
+            set_translation_for_key(key, lang, value)
+        end
+      end
+
+      def format_file(lang)
+        result = super
+        return result unless result
+        "{\n    \"@@locale\": \"%{lang}\",\n#{super}\n}\n"
+      end
+
+      def format_sections(twine_file, lang)
+        sections = twine_file.sections.map { |section| format_section(section, lang) }
+        sections.delete_if(&:empty?)
+        sections.join(",\n\n")
+      end
+
+      def format_section_header(section)
+      end
+
+      def format_section(section, lang)
+        definitions = section.definitions.dup
+
+        definitions.map! { |definition| format_definition(definition, lang) }
+        definitions.compact! # remove nil definitions
+        definitions.join(",\n")
+      end
+
+      def key_value_pattern
+        "    \"%{key}\": \"%{value}\""
+      end
+
+      def format_key(key)
+        escape_quotes(key)
+      end
+
+      def format_value(value)
+        escape_quotes(value)
+      end
+    end
+  end
+end
+
+Twine::Formatters.formatters << Twine::Formatters::Flutter.new

--- a/test/fixtures/formatter_flutter.arb
+++ b/test/fixtures/formatter_flutter.arb
@@ -1,0 +1,15 @@
+{
+    "@@locale": "en",
+
+    "key1": "value1-english",
+    "@key1": {
+        "description": "comment key1"
+    },
+    "key2": "value2-english",
+
+    "key3": "value3-english",
+    "key4": "value4-english",
+    "@key4": {
+        "description": "comment key4"
+    }
+}

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -482,6 +482,58 @@ class TestJQueryFormatter < FormatterTest
   end
 end
 
+class TestFlutterFormatter < FormatterTest
+
+  def setup
+    super Twine::Formatters::Flutter
+  end
+
+  def test_read_format
+    @formatter.read content_io('formatter_flutter.arb'), 'en'
+
+    assert_translations_read_correctly
+  end
+
+  def test_format_file
+    formatter = Twine::Formatters::Flutter.new
+    formatter.twine_file = @twine_file
+    assert_equal content('formatter_jquery.json'), formatter.format_file('en')
+  end
+
+  def test_empty_sections_are_removed
+    @twine_file = build_twine_file 'en' do
+      add_section 'Section 1' do
+      end
+
+      add_section 'Section 2' do
+        add_definition key: 'value'
+      end
+    end
+    formatter = Twine::Formatters::Flutter.new
+    formatter.twine_file = @twine_file
+    refute_includes formatter.format_file('en'), ','
+  end
+
+  def test_format_value_with_newline
+    assert_equal "value\nwith\nline\nbreaks", @formatter.format_value("value\nwith\nline\nbreaks")
+  end
+
+  def test_deducts_language_from_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("#{language}.arb")
+  end
+
+  def test_deducts_language_from_extended_filename
+    language = KNOWN_LANGUAGES.sample
+    assert_equal language, @formatter.determine_language_given_path("something-#{language}.arb")
+  end
+
+  def test_deducts_language_from_path
+    language = %w(en-GB de fr).sample
+    assert_equal language, @formatter.determine_language_given_path("lib/l10n/arb/app_#{language}.arb")
+  end
+end
+
 class TestGettextFormatter < FormatterTest
   def setup
     super Twine::Formatters::Gettext


### PR DESCRIPTION
TL;DR: need advice to finish developing a Flutter formatter.

Hi Sebastian,
I am a mobile developer on a small Italian team that develops mostly native and we use twine on many projects to keep localizations strings aligned between iOS and Android, so first of all I want to thank you for creating this project: great job!

Anyway, now I'm working on a cross-platform project using Flutter and I think that twine would still be a good option to handle localizations in a single file, so I'm trying to implement a Flutter formatter to handle ".arb" files.
These files have a syntax very similar to json so I'm taking inspiration from [this pull request](https://github.com/scelis/twine/pull/11) where I've seen you rightfully asked to also implement tests.

Keeping in mind that I have zero experience on Ruby, can you give me some advice on how to test my changes locally?
Here are some questions:

1. How can I run locally the modified twine with my added formatter? I tried simply `ruby twine.rb consume-localization-file flutter_import_test.txt app_en.arb` but it gives me error on `require 'twine/formatters/flutter'` line.
2. How can I run tests locally? As you can see I added a `TestFlutterFormatter` on `test/test_formatters.rb` but I have no clue on how to run those tests...
3. The default examples of Flutter localization insert the language in the filename, not in the path, so the `default_file_name` makes less sense in this case. How should I handle it? Defaulting to "en" language?

Excuse me for my newbie questions, but I've only written short single-file scripts in Ruby until now, so I need some hints to understand this project architecture.

Thank you and have a nice day