### PR TITLE
Add Ruby 3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@2b019609e2b0f1ea1a2bc8ca11cb82ab46ada124
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files   = Dir.glob("test/test_*")
 
   s.required_ruby_version = ">= 2.4"
+  s.add_runtime_dependency('rexml', "~> 3.2")
   s.add_runtime_dependency('rubyzip', "~> 2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
   s.add_development_dependency('rake', "~> 13.0")


### PR DESCRIPTION
As reported in #311, Ruby 3 promotes `rexml` to a gem and thus `rexml` no longer ships with the base ruby install. This caused a runtime failure in Twine when running it using Ruby 3.

This pull request adds ruby 3.0 and 3.1 to our test matrix and explicitly adds rexml as a runtime dependency.

Fixes #311