### PR TITLE
Added support for reading nested json files

### DIFF
--- a/lib/twine/formatters/jquery.rb
+++ b/lib/twine/formatters/jquery.rb
@@ -20,6 +20,16 @@ module Twine
         return super
       end
 
+      def set_translation_for_key_recursive(key, lang, value)
+        if value.is_a?(Hash)
+          value.each do |key2, value2|
+            set_translation_for_key_recursive(key+"."+key2, lang, value2)
+          end
+        else
+          set_translation_for_key(key, lang, value)
+        end
+      end
+
       def read(io, lang)
         begin
           require "json"
@@ -29,7 +39,7 @@ module Twine
 
         json = JSON.load(io)
         json.each do |key, value|
-          set_translation_for_key(key, lang, value)
+          set_translation_for_key_recursive(key, lang, value)
         end
       end
 

--- a/test/fixtures/formatter_jquery_nested.json
+++ b/test/fixtures/formatter_jquery_nested.json
@@ -1,0 +1,11 @@
+{
+"key1":"value1-english",
+"key2":"value2-english",
+
+"key3":"value3-english",
+"key4":"value4-english",
+"key5":{
+	"key5a":"value5a-english",
+	"key5b":"value5b-english"
+	}
+}

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -28,6 +28,14 @@ class FormatterTest < TwineTest
     end
   end
 
+  def assert_nested_translations_read_correctly
+    1.upto(4) do |i|
+      assert_equal "value#{i}-english", @empty_twine_file.definitions_by_key["key#{i}"].translations['en']
+    end
+    assert_equal "value5a-english", @empty_twine_file.definitions_by_key["key5.key5a"].translations['en']
+    assert_equal "value5b-english", @empty_twine_file.definitions_by_key["key5.key5b"].translations['en']
+  end
+
   def assert_file_contents_read_correctly
     assert_translations_read_correctly
 
@@ -440,6 +448,12 @@ class TestJQueryFormatter < FormatterTest
     @formatter.read content_io('formatter_jquery.json'), 'en'
 
     assert_translations_read_correctly
+  end
+
+  def test_read_format_nested
+    @formatter.read content_io('formatter_jquery_nested.json'), 'en'
+
+    assert_nested_translations_read_correctly
   end
 
   def test_format_file


### PR DESCRIPTION
This change adds support for the `consume-all-localization-files` command to be able to ingest nested json files that are used in / accepted by libraries such as i18next. 

This allows web projects using nested json translation files to be able to start a new twine file. 

Nested strings will preserve their hierarchy via `"."` (dot) notation, for example: `parent.child`.

The generated json from the twine file will then continue to use the dot notation, which should still be compatible with projects using nested json. 