### PR TITLE
Necessary adjustments to work with Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.4']
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/twine/formatters/android.rb
+++ b/lib/twine/formatters/android.rb
@@ -152,7 +152,7 @@ module Twine
 
         # capture xliff tags and replace them with a placeholder
         xliff_tags = []
-        value.gsub! /<xliff:g.+?<\/xliff:g>/ do
+        value.gsub!(/<xliff:g.+?<\/xliff:g>/) do
           xliff_tags << $&
           'TWINE_XLIFF_TAG_PLACEHOLDER'
         end
@@ -163,7 +163,7 @@ module Twine
         # put xliff tags back into place
         xliff_tags.each do |xliff_tag|
           # escape content of xliff tags
-          xliff_tag.gsub! /(<xliff:g.*?>)(.*)(<\/xliff:g>)/ do "#{$1}#{escape_value($2)}#{$3}" end
+          xliff_tag.gsub!(/(<xliff:g.*?>)(.*)(<\/xliff:g>)/) do "#{$1}#{escape_value($2)}#{$3}" end
           value.sub! 'TWINE_XLIFF_TAG_PLACEHOLDER', xliff_tag
         end
         

--- a/lib/twine/placeholders.rb
+++ b/lib/twine/placeholders.rb
@@ -70,7 +70,7 @@ module Twine
     end
 
     def convert_placeholders_from_flash_to_twine(input)
-      input.gsub /\{\d+\}/, '%@'
+      input.gsub(/\{\d+\}/, '%@')
     end
 
     # Python supports placeholders in the form of `%(amount)03d`

--- a/lib/twine/twine_file.rb
+++ b/lib/twine/twine_file.rb
@@ -1,7 +1,7 @@
 module Twine
   class TwineDefinition
     attr_reader :key
-    attr_accessor :comment
+    attr_writer :comment
     attr_accessor :tags
     attr_reader :translations
     attr_accessor :reference

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -20,7 +20,7 @@ class CLITest < TwineTest
   def assert_help
     parse_with '--help'
     assert_equal @options, false
-    assert_match /Usage: twine.*Examples:/m, Twine::stdout.string
+    assert_match(/Usage: twine.*Examples:/m, Twine::stdout.string)
   end
 
   def assert_option_consume_all

--- a/test/test_validate_twine_file.rb
+++ b/test/test_validate_twine_file.rb
@@ -38,10 +38,16 @@ class TestValidateTwineFile < CommandTest
   end
 
   def test_reports_invalid_characters_in_keys
-    random_definition.key[0] = "!?;:,^`´'\"\\|/(){}[]~-+*=#$%".chars.to_a.sample
+    invalid_character = "!?;:,^`´'\"\\|/(){}[]~-+*=#$%".chars.to_a.sample
+
+    twine_file = build_twine_file 'en' do
+      add_section 'Section' do
+        add_definition "key#{invalid_character}" => 'value'
+      end
+    end
 
     assert_raises Twine::Error do
-      Twine::Runner.new(@options, @twine_file).validate_twine_file
+      Twine::Runner.new(@options, twine_file).validate_twine_file
     end
   end
 

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -21,10 +21,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rexml', "~> 3.2")
   s.add_runtime_dependency('rubyzip', "~> 2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
+  s.add_runtime_dependency('base64', "~> 0.2")
   s.add_development_dependency('rake', "~> 13.0")
   s.add_development_dependency('minitest', "~> 5.5")
   s.add_development_dependency('minitest-ci', "~> 3.0")
-  s.add_development_dependency('mocha', "~> 1.1")
+  s.add_development_dependency('mocha', "~> 2.7")
 
   s.executables  = %w( twine )
   s.description  = <<desc


### PR DESCRIPTION
While working on https://github.com/scelis/twine/issues/318 I had to bump a few dependencies and fix some warnings to run Twine with my local Ruby 3.4. Let's see what the CI says to these changes 🤞 